### PR TITLE
Add "addFriend" action and "friends" reducer

### DIFF
--- a/HelloAgain/__tests__/actions/index.js
+++ b/HelloAgain/__tests__/actions/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import * as actions from '../../actions'
+
+describe('updateFriend', () => {
+  let bob = {name: "Bob"};
+  it('should have a friend', () => {
+    expect(actions.updateFriend(bob).friend).toMatchObject(bob)
+  })
+  it('should return a type', () => {
+    expect(actions.updateFriend(bob).type).toEqual(actions.UPDATE_FRIEND);
+  })
+})

--- a/HelloAgain/__tests__/reducers/friends.js
+++ b/HelloAgain/__tests__/reducers/friends.js
@@ -1,0 +1,38 @@
+'use strict';
+
+import friends from '../../reducers/friends'
+import * as actions from '../../actions'
+
+describe('friends reducer', () => {
+  it('should return an initial state', () => {
+    expect(
+      friends(undefined, {})
+    ).toEqual([])
+  })
+
+  let bob = {name: "Bob", recordID: 50};
+  let initialState = friends(undefined, actions.updateFriend(bob))
+  it('should add a friend', () => {
+    expect(initialState).toEqual([bob])
+  })
+
+  it('should not duplicate an existing friend', () => {
+    expect(
+      friends(initialState, actions.updateFriend(bob))
+    ).toEqual(initialState)
+  })
+
+  it("should merge a friend's existing record", () => {
+    let newFact = {recordID: 50, hobby: "fishing"}
+    let newState = friends(initialState, actions.updateFriend(newFact))
+    expect(newState.length).toEqual(1)
+    expect(newState[0]).toMatchObject({...bob, ...newFact})
+  })
+
+  let jim = {name: "Jim", recordID: 42};
+  it('should add a new friend at the front', () => {
+    expect(
+      friends(initialState, actions.updateFriend(jim))
+    ).toEqual([jim, bob])
+  })
+})

--- a/HelloAgain/__tests__/reducers/index.js
+++ b/HelloAgain/__tests__/reducers/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+import mainReducer from '../../reducers'
+
+describe('main reducer', () => {
+  it('should have friends', () => {
+    expect(
+      mainReducer(undefined, {}).friends
+    ).toBeDefined();
+  })
+})

--- a/HelloAgain/actions/index.js
+++ b/HelloAgain/actions/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Enumerate the dispatchable actions.
+export const UPDATE_FRIEND = 'UPDATE_FRIEND'
+
+// Helpers for dispatching actions.
+export const updateFriend = (friend) => {
+  return { type: UPDATE_FRIEND, friend: friend }
+}

--- a/HelloAgain/reducers/friends.js
+++ b/HelloAgain/reducers/friends.js
@@ -1,0 +1,37 @@
+'use strict';
+
+import { UPDATE_FRIEND } from '../actions';
+
+const RECORD_ID = "recordID";
+
+const findFriendIndex = (state, friend) => {
+  return state.findIndex((f) => {
+    return f[RECORD_ID] == friend[RECORD_ID]
+  })
+}
+
+const friends = (state = [], action) => {
+  switch (action.type) {
+    case UPDATE_FRIEND:
+      let newFriend = {}
+      // If the friend is already in the store, then copy the existing record.
+      let existing = findFriendIndex(state, action.friend)
+      if (existing > -1) {
+        Object.assign(newFriend, state[existing])
+      }
+      // Merge in the new record.
+      Object.assign(newFriend, action.friend)
+      // Copy the existing state and replace or add the updated friend.
+      let newState = [...state]
+      if (existing > -1) {
+        newState[existing] = newFriend
+      } else {
+        newState.unshift(newFriend)
+      }
+      return newState
+    default:
+      return state
+  }
+}
+
+export default friends

--- a/HelloAgain/reducers/index.js
+++ b/HelloAgain/reducers/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import { combineReducers } from 'redux'
+import friends from './friends'
+
+const mainReducer = combineReducers({
+  friends
+})
+
+export default mainReducer

--- a/HelloAgain/store.js
+++ b/HelloAgain/store.js
@@ -1,0 +1,8 @@
+'use strict';
+
+import { createStore } from 'redux'
+import mainReducer from '../reducers'
+
+const store = createStore(mainReducer)
+
+export default store


### PR DESCRIPTION
This PR lays out the basic structure for adding Redux actions and reducers to the project.

Included is an initial reducer for maintaining the state of `friends`, with an `UPDATE_FRIEND` action that upserts a friend into the queue, adding the friend to the top of the queue if they weren't already present.

Also included are a top-level Redux reducer and a Redux store that uses it.

@obra: please review