### PR TITLE
Add toggleActive action on friends.

### DIFF
--- a/HelloAgain/__tests__/actions/__snapshots__/contact.js.snap
+++ b/HelloAgain/__tests__/actions/__snapshots__/contact.js.snap
@@ -1,0 +1,8 @@
+exports[`toggleActive should return an action 1`] = `
+Object {
+  "friend": Object {
+    "name": "Bob",
+  },
+  "type": "TOGGLE_ACTIVE",
+}
+`;

--- a/HelloAgain/__tests__/actions/contact.js
+++ b/HelloAgain/__tests__/actions/contact.js
@@ -1,0 +1,12 @@
+'use strict';
+
+import * as actions from '../../actions/contact'
+
+describe('toggleActive', () => {
+  it('should return an action', () => {
+    let bob = {name: "Bob"};
+    expect(
+      actions.toggleActive(bob)
+    ).toMatchSnapshot()
+  })
+})

--- a/HelloAgain/__tests__/reducers/__snapshots__/friends.js.snap
+++ b/HelloAgain/__tests__/reducers/__snapshots__/friends.js.snap
@@ -1,0 +1,29 @@
+exports[`friends reducer toggleActive action should toggle a new friend active 1`] = `
+Object {
+  "50": Object {
+    "isActive": true,
+    "name": "Bob",
+    "recordID": 50,
+  },
+}
+`;
+
+exports[`friends reducer toggleActive action should toggle an existing friend (in)active 1`] = `
+Object {
+  "50": Object {
+    "isActive": false,
+    "name": "Bob",
+    "recordID": 50,
+  },
+}
+`;
+
+exports[`friends reducer toggleActive action should toggle an existing friend (in)active 2`] = `
+Object {
+  "50": Object {
+    "isActive": true,
+    "name": "Bob",
+    "recordID": 50,
+  },
+}
+`;

--- a/HelloAgain/__tests__/reducers/friends.js
+++ b/HelloAgain/__tests__/reducers/friends.js
@@ -2,36 +2,59 @@
 
 import friends from '../../reducers/friends'
 import * as actions from '../../actions/friend'
+import * as contactActions from '../../actions/contact'
 
 describe('friends reducer', () => {
+  let bob = {name: "Bob", recordID: 50}
+
   it('should return an initial state', () => {
     expect(
       friends(undefined, {})
     ).toEqual({})
   })
 
-  let bob = {name: "Bob", recordID: 50};
-  let initialState = friends(undefined, actions.updateFriend(bob))
-  it('should add a friend', () => {
-    expect(initialState).toEqual({50: bob})
+  describe('updateFriend action', () => {
+    let initialState = friends(undefined, actions.updateFriend(bob))
+    it('should add a friend', () => {
+      expect(initialState).toEqual({50: bob})
+    })
+
+    it('should not duplicate an existing friend', () => {
+      expect(
+        friends(initialState, actions.updateFriend(bob))
+      ).toEqual(initialState)
+    })
+
+    it("should merge a friend's existing record", () => {
+      let newFact = {recordID: 50, hobby: "fishing"}
+      let newState = friends(initialState, actions.updateFriend(newFact))
+      expect(newState).toMatchObject({50: {...bob, ...newFact}})
+    })
+
+    let jim = {name: "Jim", recordID: 42};
+    it('should add a new friend at the front', () => {
+      expect(
+        friends(initialState, actions.updateFriend(jim))
+      ).toEqual({50: bob, 42: jim})
+    })
   })
 
-  it('should not duplicate an existing friend', () => {
-    expect(
-      friends(initialState, actions.updateFriend(bob))
-    ).toEqual(initialState)
-  })
+  describe('toggleActive action', () => {
+    it('should toggle a new friend active', () => {
+      let state = friends(undefined, contactActions.toggleActive(bob))
+      expect(state).toMatchSnapshot()
+    })
 
-  it("should merge a friend's existing record", () => {
-    let newFact = {recordID: 50, hobby: "fishing"}
-    let newState = friends(initialState, actions.updateFriend(newFact))
-    expect(newState).toMatchObject({50: {...bob, ...newFact}})
-  })
+    it('should toggle an existing friend (in)active', () => {
+      let state = friends(undefined, actions.updateFriend({...bob, isActive: true}))
 
-  let jim = {name: "Jim", recordID: 42};
-  it('should add a new friend at the front', () => {
-    expect(
-      friends(initialState, actions.updateFriend(jim))
-    ).toEqual({50: bob, 42: jim})
+      // Now Bob is inactive
+      state = friends(state, contactActions.toggleActive(bob))
+      expect(state).toMatchSnapshot()
+
+      // Now Bob is active
+      state = friends(state, contactActions.toggleActive(bob))
+      expect(state).toMatchSnapshot()
+    })
   })
 })

--- a/HelloAgain/actions/contact.js
+++ b/HelloAgain/actions/contact.js
@@ -1,0 +1,9 @@
+'use strict'
+
+import {
+  TOGGLE_ACTIVE
+} from './types';
+
+export const toggleActive = (friend) => {
+  return { type: TOGGLE_ACTIVE, friend: friend }
+}

--- a/HelloAgain/reducers/friends.js
+++ b/HelloAgain/reducers/friends.js
@@ -1,11 +1,16 @@
 'use strict';
 
 import { 
-  UPDATE_FRIEND
+  UPDATE_FRIEND,
+  TOGGLE_ACTIVE
 } from '../actions/types';
 
 const _id = (friend) => {
   return friend.recordID
+}
+
+const findFriend = (state, friend) => {
+  return state[_id(friend)] 
 }
 
 const updateFriend = (state, update) => {
@@ -16,6 +21,10 @@ const updateFriend = (state, update) => {
 
 const friends = (state = {}, action) => {
   switch (action.type) {
+    case TOGGLE_ACTIVE:
+      let existingFriend = findFriend(state, action.friend)
+      let isActive = (existingFriend ? existingFriend.isActive : false)
+      return updateFriend(state, {...action.friend, isActive: !isActive})
     case UPDATE_FRIEND:
       return updateFriend(state, action.friend)
     default:


### PR DESCRIPTION
Adds a `toggleActive` action on friends/contacts, creating the friend record (and defaulting to `isActive: true`) if the contact doesn't exist in the friend list yet.

@obra, please review