### PR TITLE
Add Contact and ContactList presentation components.

### DIFF
--- a/HelloAgain/__tests__/components/__snapshots__/contact-list.js.snap
+++ b/HelloAgain/__tests__/components/__snapshots__/contact-list.js.snap
@@ -1,0 +1,691 @@
+exports[`test renders a list of contacts 1`] = `
+<ScrollView
+  dataSource={
+    ListViewDataSource {
+      "items": 17,
+    }
+  }
+  initialListSize={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={1000}
+  onKeyboardDidHide={undefined}
+  onKeyboardDidShow={undefined}
+  onKeyboardWillHide={undefined}
+  onKeyboardWillShow={undefined}
+  onLayout={[Function]}
+  onScroll={[Function]}
+  pageSize={1}
+  removeClippedSubviews={true}
+  renderRow={[Function]}
+  scrollEventThrottle={50}
+  scrollRenderAheadDistance={1000}
+  stickyHeaderIndices={Array []}
+  style={
+    Object {
+      "alignSelf": "stretch",
+      "backgroundColor": "#ffffff",
+      "paddingTop": 20,
+    }
+  }>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Nicolaus
+         
+        Copernicus
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Tycho
+         
+        Brahe
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Clyde
+         
+        Tombaugh
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        William
+         
+        Herschel
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        John
+         
+        Herschel
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Charles
+         
+        Messier
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Henrietta
+         
+        Leavitt
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Jérôme
+         
+        Lalande
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Ejnar
+         
+        Herzsprung
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Edwin
+         
+        Hubble
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</ScrollView>
+`;

--- a/HelloAgain/__tests__/components/__snapshots__/contact.js.snap
+++ b/HelloAgain/__tests__/components/__snapshots__/contact.js.snap
@@ -1,0 +1,137 @@
+exports[`test renders a contact 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+      },
+      undefined,
+    ]
+  }
+  testID={undefined}>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#F5FCFF",
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-around",
+        "padding": 5,
+      }
+    }>
+    <Image
+      source={Object {}}
+      style={undefined} />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "flex": 5,
+          "fontSize": 20,
+          "marginBottom": 5,
+          "textAlign": "left",
+        }
+      }>
+      Nicolaus
+       
+      Copernicus
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "fontSize": 25,
+          "marginRight": 15,
+          "textAlign": "right",
+        }
+      }>
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`test renders an active contact 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+      },
+      undefined,
+    ]
+  }
+  testID={undefined}>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#F5FCFF",
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-around",
+        "padding": 5,
+      }
+    }>
+    <Image
+      source={Object {}}
+      style={undefined} />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "flex": 5,
+          "fontSize": 20,
+          "marginBottom": 5,
+          "textAlign": "left",
+        }
+      }>
+      Nicolaus
+       
+      Copernicus
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "fontSize": 25,
+          "marginRight": 15,
+          "textAlign": "right",
+        }
+      }>
+      ✓
+    </Text>
+  </View>
+</View>
+`;

--- a/HelloAgain/__tests__/components/contact-list.js
+++ b/HelloAgain/__tests__/components/contact-list.js
@@ -1,0 +1,13 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { CONTACT_FIXTURE } from "../fixtures/contacts"
+import ContactList from "../../components/contact-list"
+
+it('renders a list of contacts', () => {
+  expect(renderer.create(
+    <ContactList items={CONTACT_FIXTURE} />
+  )).toMatchSnapshot();
+})

--- a/HelloAgain/__tests__/components/contact.js
+++ b/HelloAgain/__tests__/components/contact.js
@@ -1,0 +1,22 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { CONTACT_FIXTURE } from "../fixtures/contacts"
+import Contact from "../../components/contact"
+
+it('renders a contact', () => {
+  let fixture = CONTACT_FIXTURE[0]
+  expect(renderer.create(
+    <Contact {...fixture} />
+  )).toMatchSnapshot();
+})
+
+it('renders an active contact', () => {
+  let fixture = {...CONTACT_FIXTURE[0], isActive: true}
+  expect(renderer.create(
+    <Contact {...fixture} />
+  )).toMatchSnapshot();
+})
+

--- a/HelloAgain/__tests__/fixtures/contacts.js
+++ b/HelloAgain/__tests__/fixtures/contacts.js
@@ -1,0 +1,25 @@
+'use strict'
+
+export const CONTACT_FIXTURE = [
+    { recordID: 1, familyName: "Copernicus", givenName: "Nicolaus" },
+    { recordID: 2, familyName: "Brahe", givenName: "Tycho" },
+    { recordID: 3, familyName: "Tombaugh", givenName: "Clyde" },
+    { recordID: 4, familyName: "Herschel", givenName: "William" },
+    { recordID: 5, familyName: "Herschel", givenName: "John" },
+    { recordID: 6, familyName: "Messier", givenName: "Charles" },
+    { recordID: 7, familyName: "Leavitt", givenName: "Henrietta", middleName: "Swan" },
+    { recordID: 8, familyName: "Lalande", givenName: "Jérôme" },
+    { recordID: 9, familyName: "Herzsprung", givenName: "Ejnar" },
+    { recordID: 10, familyName: "Hubble", givenName: "Edwin" },
+    { recordID: 11, familyName: "Rubin", givenName: "Vera" },
+    { recordID: 12, familyName: "Kepler", givenName: "Johannes" },
+    { recordID: 13, familyName: "Humason", givenName: "Milton", middleName: "L." },
+    { recordID: 14, familyName: "Oort", givenName: "Jan" },
+    { recordID: 15, familyName: "Klumpke", givenName: "Dorothea" },
+    { recordID: 16, familyName: "Struve", givenName: "Gustav Wilhelm Ludvig" },
+    { recordID: 17, familyName: "Wolf", givenName: "Max" },
+]
+
+it("contains fixtures", () => {
+  expect(CONTACT_FIXTURE).toBeTruthy()
+})

--- a/HelloAgain/components/contact-list.js
+++ b/HelloAgain/components/contact-list.js
@@ -1,0 +1,42 @@
+'use strict';
+
+import React, { Component } from 'react'
+import {
+  ListView,
+  StyleSheet
+} from 'react-native'
+
+import Contact from './contact'
+
+export default class ContactList extends Component {
+  constructor(props) {
+    super(props);
+    this.dataSource = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2})
+  }
+
+  renderContact(rowData) {
+    return (
+      <Contact {...rowData} onPress={this.props.onContactPress} />
+    )
+  }
+
+  render() {
+    return (
+      <ListView
+        dataSource={this.dataSource.cloneWithRows(this.props.items)}
+        renderRow={
+          this.props.renderRow ||
+          this.renderContact.bind(this) }
+        style={styles.contactList}
+      />
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  contactList: {
+    paddingTop: 20,
+    alignSelf: 'stretch',
+    backgroundColor: '#ffffff',
+  }
+})

--- a/HelloAgain/components/contact.js
+++ b/HelloAgain/components/contact.js
@@ -1,0 +1,53 @@
+'use strict';
+
+import React, { Component } from 'react';
+import {
+  Text,
+  View,
+  StyleSheet,
+  TouchableHighlight,
+  Image
+} from 'react-native'
+
+export default class Contact extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    var imageSource = {};
+    if (this.props.thumbnailPath) {
+      imageSource.uri = this.props.thumbnailPath
+    }
+    return (
+      <TouchableHighlight onPress={() => this.props.onPress(this.props)}>
+        <View style={styles.contactRow}>
+          <Image style={styles.contactPicture} source={imageSource} />
+          <Text style={styles.contactName}>{this.props.givenName} {this.props.familyName}</Text>
+          <Text style={styles.contactActive}>{this.props.isActive ? '✓' : ''}</Text>
+        </View>
+      </TouchableHighlight>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  contactRow: {
+    flex: 1,
+    padding: 5,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    backgroundColor: '#F5FCFF',
+  },
+  contactName: {
+    marginBottom: 5,
+    textAlign: 'left',
+    fontSize: 20,
+    flex: 5
+  },
+  contactActive: {
+    marginRight: 15,
+    textAlign: 'right',
+    fontSize: 25
+  }  
+})


### PR DESCRIPTION
The `ContactList` component is a presentational component designed to support both the contact picker and the friend queue. The `Contact` component implements the individual list item for the contact picker.

The presentational components get wired up to container components in a forthcoming PR: a `ContactPicker` container will employ the `ContactList` to display all contacts, and let a user select which to set as active friends; a `FriendQueue` container will use same to show the ordered list of friends in the queue.

There's a very sensible [blog post](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.b5r8tdpnx) by Abramov, the author of Redux, that clarifies the idea of presentational vs. container components.

Also, this PR adds some contact entry fixtures.

Sorry for the huge snapshot blobs; it seems to be one of the downsides of using Jest snapshots.

@obra, please review

Next step is to figure out how to test the "press" event for selecting/unselecting a contact.