### PR TITLE
Integrate enzyme to aid in testing user interactions.

### DIFF
--- a/HelloAgain/__tests__/components/contact-list.js
+++ b/HelloAgain/__tests__/components/contact-list.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme'
 
 import { CONTACT_FIXTURE } from "../fixtures/contacts"
 import ContactList from "../../components/contact-list"
@@ -10,4 +11,12 @@ it('renders a list of contacts', () => {
   expect(renderer.create(
     <ContactList items={CONTACT_FIXTURE} />
   )).toMatchSnapshot();
+})
+
+it('accepts a renderRow prop', () => {
+  const renderRow = () => {}
+  const wrapper = shallow(
+    <ContactList items={CONTACT_FIXTURE} renderRow={renderRow} />
+  )
+  expect(wrapper.find("ListView").prop("renderRow")).toBe(renderRow)
 })

--- a/HelloAgain/__tests__/components/contact.js
+++ b/HelloAgain/__tests__/components/contact.js
@@ -2,6 +2,9 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import sinon from 'sinon'
+import { shallow } from 'enzyme'
+
 
 import { CONTACT_FIXTURE } from "../fixtures/contacts"
 import Contact from "../../components/contact"
@@ -20,3 +23,13 @@ it('renders an active contact', () => {
   )).toMatchSnapshot();
 })
 
+it('provides its props when pressed', () => {
+  const fixture = CONTACT_FIXTURE[0]
+  const onPress = sinon.spy()
+  const wrapper = shallow(
+    <Contact {...fixture} onPress={onPress} />
+  )
+  wrapper.simulate("press")
+  expect(onPress.calledOnce).toBe(true)
+  expect(onPress.args[0][0]).toMatchObject(fixture)
+})

--- a/HelloAgain/package.json
+++ b/HelloAgain/package.json
@@ -15,8 +15,12 @@
     "babel-cli": "^6.18.0",
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.1",
+    "enzyme": "^2.7.0",
     "jest": "18.1.0",
-    "react-test-renderer": "15.4.2"
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "react-test-renderer": "15.4.2",
+    "sinon": "^1.17.7"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
As promised, this PR provides for testing the behavior of shallow-rendered React Native components, including simulating user interaction events, using the [enzyme](https://github.com/airbnb/enzyme/) library.

http://www.multunus.com/blog/2016/07/test-driving-react-native-applications/

A simple onPress test for the `Contact` row component is included, plus a little check to make sure that the props intended to make `ContactList` flexible enough to support rendering different kinds of row elements actually work as intended.

@obra, please to have a glance
