### PR TITLE
Put the Contact item data into an 'item' prop

### DIFF
--- a/HelloAgain/__tests__/components/contact.js
+++ b/HelloAgain/__tests__/components/contact.js
@@ -12,14 +12,14 @@ import Contact from "../../components/contact"
 it('renders a contact', () => {
   let fixture = CONTACT_FIXTURE[0]
   expect(renderer.create(
-    <Contact {...fixture} />
+    <Contact item={fixture} />
   )).toMatchSnapshot();
 })
 
 it('renders an active contact', () => {
   let fixture = {...CONTACT_FIXTURE[0], isActive: true}
   expect(renderer.create(
-    <Contact {...fixture} />
+    <Contact item={fixture} />
   )).toMatchSnapshot();
 })
 
@@ -27,7 +27,7 @@ it('provides its props when pressed', () => {
   const fixture = CONTACT_FIXTURE[0]
   const onPress = sinon.spy()
   const wrapper = shallow(
-    <Contact {...fixture} onPress={onPress} />
+    <Contact item={fixture} onPress={onPress} />
   )
   wrapper.simulate("press")
   expect(onPress.calledOnce).toBe(true)

--- a/HelloAgain/components/contact-list.js
+++ b/HelloAgain/components/contact-list.js
@@ -16,7 +16,7 @@ export default class ContactList extends Component {
 
   renderContact(rowData) {
     return (
-      <Contact {...rowData} onPress={this.props.onContactPress} />
+      <Contact item={rowData} onPress={this.props.onContactPress} />
     )
   }
 

--- a/HelloAgain/components/contact.js
+++ b/HelloAgain/components/contact.js
@@ -15,16 +15,17 @@ export default class Contact extends Component {
   }
 
   render() {
+    const item = this.props.item;
     var imageSource = {};
-    if (this.props.thumbnailPath) {
-      imageSource.uri = this.props.thumbnailPath
+    if (item.thumbnailPath) {
+      imageSource.uri = item.thumbnailPath
     }
     return (
-      <TouchableHighlight onPress={() => this.props.onPress(this.props)}>
+      <TouchableHighlight onPress={() => this.props.onPress(item)}>
         <View style={styles.contactRow}>
           <Image style={styles.contactPicture} source={imageSource} />
-          <Text style={styles.contactName}>{this.props.givenName} {this.props.familyName}</Text>
-          <Text style={styles.contactActive}>{this.props.isActive ? '✓' : ''}</Text>
+          <Text style={styles.contactName}>{item.givenName} {item.familyName}</Text>
+          <Text style={styles.contactActive}>{item.isActive ? '✓' : ''}</Text>
         </View>
       </TouchableHighlight>
     )


### PR DESCRIPTION
Keeps the individual contact data separate from event handlers on the Contact component. This way the contact record can simply be passed to the friends reducer without having to filter out UI stuff that should _not_ go into the redux store.

@obra, please review. Hope this is entertaining you :)