### PR TITLE
Add ContactPicker container for toggling contacts/friends.

### DIFF
--- a/HelloAgain/__tests__/containers/__snapshots__/contact-picker.js.snap
+++ b/HelloAgain/__tests__/containers/__snapshots__/contact-picker.js.snap
@@ -1,0 +1,691 @@
+exports[`test renders a list of contacts 1`] = `
+<ScrollView
+  dataSource={
+    ListViewDataSource {
+      "items": 17,
+    }
+  }
+  initialListSize={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={1000}
+  onKeyboardDidHide={undefined}
+  onKeyboardDidShow={undefined}
+  onKeyboardWillHide={undefined}
+  onKeyboardWillShow={undefined}
+  onLayout={[Function]}
+  onScroll={[Function]}
+  pageSize={1}
+  removeClippedSubviews={true}
+  renderRow={[Function]}
+  scrollEventThrottle={50}
+  scrollRenderAheadDistance={1000}
+  stickyHeaderIndices={Array []}
+  style={
+    Object {
+      "alignSelf": "stretch",
+      "backgroundColor": "#ffffff",
+      "paddingTop": 20,
+    }
+  }>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Nicolaus
+         
+        Copernicus
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Tycho
+         
+        Brahe
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Clyde
+         
+        Tombaugh
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        William
+         
+        Herschel
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        John
+         
+        Herschel
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Charles
+         
+        Messier
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Henrietta
+         
+        Leavitt
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Jérôme
+         
+        Lalande
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Ejnar
+         
+        Herzsprung
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Edwin
+         
+        Hubble
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+</ScrollView>
+`;

--- a/HelloAgain/__tests__/containers/contact-picker.js
+++ b/HelloAgain/__tests__/containers/contact-picker.js
@@ -1,0 +1,38 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme'
+import configureStore from 'redux-mock-store'
+
+import { CONTACT_FIXTURE } from "../fixtures/contacts"
+import { TOGGLE_ACTIVE } from "../../actions/types"
+import ContactPicker from "../../containers/contact-picker"
+
+const mockStore = configureStore([])
+const store = mockStore({contacts: CONTACT_FIXTURE})
+
+it('renders a list of contacts', () => {
+  expect(renderer.create(
+    <ContactPicker store={store} />
+  )).toMatchSnapshot()
+})
+
+it('picks up a list of contacts from the store', () => {
+  const wrapper = shallow(
+    <ContactPicker store={store} />
+  )
+  const items = wrapper.prop("items")
+  expect(items).toEqual(CONTACT_FIXTURE)
+})
+
+it('can toggle a contact', () => {
+  const wrapper = shallow(
+    <ContactPicker store={store} />
+  )
+  const items = wrapper.prop("items")
+  const contact = items[0]
+  wrapper.props().onContactPress(contact)
+  const actions = store.getActions()
+  expect(actions[0]).toMatchObject({ type: TOGGLE_ACTIVE, friend: contact })
+})

--- a/HelloAgain/containers/contact-picker.js
+++ b/HelloAgain/containers/contact-picker.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import ContactList from '../components/contact-list'
+import { toggleActive } from '../actions/contact'
+
+const mapStateToProps = (state) => {
+  return {
+    items: state.contacts
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    onContactPress: (item) => { dispatch(toggleActive(item)) }
+  }
+  // return bindActionCreators(ContactActions, dispatch)
+}
+
+const ContactPicker = connect(mapStateToProps, mapDispatchToProps)(ContactList)
+export default ContactPicker 

--- a/HelloAgain/package.json
+++ b/HelloAgain/package.json
@@ -21,6 +21,7 @@
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-test-renderer": "15.4.2",
+    "redux-mock-store": "^1.2.1",
     "sinon": "^1.17.7"
   },
   "jest": {

--- a/HelloAgain/package.json
+++ b/HelloAgain/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "react": "15.4.2",
     "react-native": "0.40.0",
+    "react-redux": "^5.0.2",
     "redux": "^3.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In keeping with the division of labor between [presentational and container components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.8omq5e34i), we have here the `ContactPicker` container, which uses the `ContactList` component to render a list of `Contacts`.

The `ContactList` container is given an `onContactPress` callback by `ContactPicker` in the `mapDispatchToProps` function (a [react-redux idiom](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)), which it passes to its children as their `onPress` event.

The `onContactPress` callback itself is nothing other than a dispatch of the `toggleActive` action to the `friends` redux store, with the contact data associated with that `Contact` component.

Meaning: when a user presses a contact in the contact picker list, it toggles their `isActive` state and updates their record in the store! 🎉 

The next step will be to wire this all the way up to the top-level React Native app home screen, bringing us right back to where we were circa a year ago... but this time with pure-functional state management and reasonably extensive unit tests. 🎊 

BTW sorry again for the huge component render snapshot. Page all the way down to the bottom for the actual code. (There must be some way to keep Github from showing these `.snap` files on every PR.)

@obra, if you please