### PR TITLE
Wire up the root HelloAgain application element to ContactPicker!

### DIFF
--- a/HelloAgain/__tests__/containers/__snapshots__/contact-picker.js.snap
+++ b/HelloAgain/__tests__/containers/__snapshots__/contact-picker.js.snap
@@ -1,3 +1,95 @@
+exports[`test picks up a sorted list of contacts from the store 1`] = `
+Array [
+  Object {
+    "familyName": "Messier",
+    "givenName": "Charles",
+    "recordID": 6,
+  },
+  Object {
+    "familyName": "Tombaugh",
+    "givenName": "Clyde",
+    "recordID": 3,
+  },
+  Object {
+    "familyName": "Klumpke",
+    "givenName": "Dorothea",
+    "recordID": 15,
+  },
+  Object {
+    "familyName": "Hubble",
+    "givenName": "Edwin",
+    "recordID": 10,
+  },
+  Object {
+    "familyName": "Herzsprung",
+    "givenName": "Ejnar",
+    "recordID": 9,
+  },
+  Object {
+    "familyName": "Struve",
+    "givenName": "Gustav Wilhelm Ludvig",
+    "recordID": 16,
+  },
+  Object {
+    "familyName": "Leavitt",
+    "givenName": "Henrietta",
+    "middleName": "Swan",
+    "recordID": 7,
+  },
+  Object {
+    "familyName": "Oort",
+    "givenName": "Jan",
+    "recordID": 14,
+  },
+  Object {
+    "familyName": "Kepler",
+    "givenName": "Johannes",
+    "recordID": 12,
+  },
+  Object {
+    "familyName": "Herschel",
+    "givenName": "John",
+    "recordID": 5,
+  },
+  Object {
+    "familyName": "Lalande",
+    "givenName": "Jérôme",
+    "recordID": 8,
+  },
+  Object {
+    "familyName": "Wolf",
+    "givenName": "Max",
+    "recordID": 17,
+  },
+  Object {
+    "familyName": "Humason",
+    "givenName": "Milton",
+    "middleName": "L.",
+    "recordID": 13,
+  },
+  Object {
+    "familyName": "Copernicus",
+    "givenName": "Nicolaus",
+    "recordID": 1,
+  },
+  Object {
+    "familyName": "Brahe",
+    "givenName": "Tycho",
+    "recordID": 2,
+  },
+  Object {
+    "familyName": "Rubin",
+    "givenName": "Vera",
+    "recordID": 11,
+  },
+  Object {
+    "familyName": "Herschel",
+    "givenName": "William",
+    "recordID": 4,
+  },
+]
+`;
+
 exports[`test renders a list of contacts 1`] = `
 <ScrollView
   dataSource={
@@ -74,75 +166,9 @@ exports[`test renders a list of contacts 1`] = `
             "textAlign": "left",
           }
         }>
-        Nicolaus
+        Charles
          
-        Copernicus
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "fontSize": 25,
-            "marginRight": 15,
-            "textAlign": "right",
-          }
-        }>
-        
-      </Text>
-    </View>
-  </View>
-  <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "backgroundColor": "transparent",
-        },
-        undefined,
-      ]
-    }
-    testID={undefined}>
-    <View
-      style={
-        Object {
-          "backgroundColor": "#F5FCFF",
-          "flex": 1,
-          "flexDirection": "row",
-          "justifyContent": "space-around",
-          "padding": 5,
-        }
-      }>
-      <Image
-        source={Object {}}
-        style={undefined} />
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "flex": 5,
-            "fontSize": 20,
-            "marginBottom": 5,
-            "textAlign": "left",
-          }
-        }>
-        Tycho
-         
-        Brahe
+        Messier
       </Text>
       <Text
         accessible={true}
@@ -272,9 +298,9 @@ exports[`test renders a list of contacts 1`] = `
             "textAlign": "left",
           }
         }>
-        William
+        Dorothea
          
-        Herschel
+        Klumpke
       </Text>
       <Text
         accessible={true}
@@ -338,207 +364,9 @@ exports[`test renders a list of contacts 1`] = `
             "textAlign": "left",
           }
         }>
-        John
+        Edwin
          
-        Herschel
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "fontSize": 25,
-            "marginRight": 15,
-            "textAlign": "right",
-          }
-        }>
-        
-      </Text>
-    </View>
-  </View>
-  <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "backgroundColor": "transparent",
-        },
-        undefined,
-      ]
-    }
-    testID={undefined}>
-    <View
-      style={
-        Object {
-          "backgroundColor": "#F5FCFF",
-          "flex": 1,
-          "flexDirection": "row",
-          "justifyContent": "space-around",
-          "padding": 5,
-        }
-      }>
-      <Image
-        source={Object {}}
-        style={undefined} />
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "flex": 5,
-            "fontSize": 20,
-            "marginBottom": 5,
-            "textAlign": "left",
-          }
-        }>
-        Charles
-         
-        Messier
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "fontSize": 25,
-            "marginRight": 15,
-            "textAlign": "right",
-          }
-        }>
-        
-      </Text>
-    </View>
-  </View>
-  <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "backgroundColor": "transparent",
-        },
-        undefined,
-      ]
-    }
-    testID={undefined}>
-    <View
-      style={
-        Object {
-          "backgroundColor": "#F5FCFF",
-          "flex": 1,
-          "flexDirection": "row",
-          "justifyContent": "space-around",
-          "padding": 5,
-        }
-      }>
-      <Image
-        source={Object {}}
-        style={undefined} />
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "flex": 5,
-            "fontSize": 20,
-            "marginBottom": 5,
-            "textAlign": "left",
-          }
-        }>
-        Henrietta
-         
-        Leavitt
-      </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "fontSize": 25,
-            "marginRight": 15,
-            "textAlign": "right",
-          }
-        }>
-        
-      </Text>
-    </View>
-  </View>
-  <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "backgroundColor": "transparent",
-        },
-        undefined,
-      ]
-    }
-    testID={undefined}>
-    <View
-      style={
-        Object {
-          "backgroundColor": "#F5FCFF",
-          "flex": 1,
-          "flexDirection": "row",
-          "justifyContent": "space-around",
-          "padding": 5,
-        }
-      }>
-      <Image
-        source={Object {}}
-        style={undefined} />
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-        style={
-          Object {
-            "flex": 5,
-            "fontSize": 20,
-            "marginBottom": 5,
-            "textAlign": "left",
-          }
-        }>
-        Jérôme
-         
-        Lalande
+        Hubble
       </Text>
       <Text
         accessible={true}
@@ -668,9 +496,273 @@ exports[`test renders a list of contacts 1`] = `
             "textAlign": "left",
           }
         }>
-        Edwin
+        Gustav Wilhelm Ludvig
          
-        Hubble
+        Struve
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Henrietta
+         
+        Leavitt
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Jan
+         
+        Oort
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        Johannes
+         
+        Kepler
+      </Text>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontSize": 25,
+            "marginRight": 15,
+            "textAlign": "right",
+          }
+        }>
+        
+      </Text>
+    </View>
+  </View>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "backgroundColor": "transparent",
+        },
+        undefined,
+      ]
+    }
+    testID={undefined}>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F5FCFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-around",
+          "padding": 5,
+        }
+      }>
+      <Image
+        source={Object {}}
+        style={undefined} />
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "flex": 5,
+            "fontSize": 20,
+            "marginBottom": 5,
+            "textAlign": "left",
+          }
+        }>
+        John
+         
+        Herschel
       </Text>
       <Text
         accessible={true}

--- a/HelloAgain/__tests__/containers/app.js
+++ b/HelloAgain/__tests__/containers/app.js
@@ -1,11 +1,11 @@
 import 'react-native';
 import React from 'react';
-import HelloAgain from '../containers/app'
+import HelloAgain from '../../containers/app'
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
-it('renders correctly', () => {
+it('renders something', () => {
   const tree = renderer.create(
     <HelloAgain />
   );

--- a/HelloAgain/__tests__/containers/contact-picker.js
+++ b/HelloAgain/__tests__/containers/contact-picker.js
@@ -5,12 +5,12 @@ import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme'
 import configureStore from 'redux-mock-store'
 
-import { CONTACT_FIXTURE } from "../fixtures/contacts"
 import { TOGGLE_ACTIVE } from "../../actions/types"
 import ContactPicker from "../../containers/contact-picker"
+import FRIENDS_FIXTURE from "../fixtures/friends"
 
 const mockStore = configureStore([])
-const store = mockStore({contacts: CONTACT_FIXTURE})
+const store = mockStore({friends: FRIENDS_FIXTURE})
 
 it('renders a list of contacts', () => {
   expect(renderer.create(
@@ -18,12 +18,12 @@ it('renders a list of contacts', () => {
   )).toMatchSnapshot()
 })
 
-it('picks up a list of contacts from the store', () => {
+it('picks up a sorted list of contacts from the store', () => {
   const wrapper = shallow(
     <ContactPicker store={store} />
   )
   const items = wrapper.prop("items")
-  expect(items).toEqual(CONTACT_FIXTURE)
+  expect(items).toMatchSnapshot()
 })
 
 it('can toggle a contact', () => {

--- a/HelloAgain/__tests__/fixtures/friends.js
+++ b/HelloAgain/__tests__/fixtures/friends.js
@@ -1,0 +1,8 @@
+"use strict";
+
+import {CONTACT_FIXTURE} from "./contacts"
+
+const FRIENDS_FIXTURE = {}
+CONTACT_FIXTURE.forEach((item) => {FRIENDS_FIXTURE[item.recordID] = item})
+
+export default FRIENDS_FIXTURE

--- a/HelloAgain/containers/app.js
+++ b/HelloAgain/containers/app.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react'
+import { Provider } from 'react-redux'
+import store from '../store'
+import ContactPicker from './contact-picker'
+
+export default class HelloAgain extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <Provider store={store}>
+        <ContactPicker />
+      </Provider>
+    )
+  }
+}

--- a/HelloAgain/containers/contact-picker.js
+++ b/HelloAgain/containers/contact-picker.js
@@ -1,13 +1,20 @@
 'use strict'
 
-// import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import ContactList from '../components/contact-list'
 import { toggleActive } from '../actions/contact'
 
 const mapStateToProps = (state) => {
+  const contacts = Object.values(state.friends)
+  contacts.sort((a, b) => {
+    if (a.givenName == b.givenName) {
+      return (a.familyName < b.familyName) ? -1 : 1;
+    } else {
+      return (a.givenName < b.givenName) ? -1 : 1;
+    }
+  })
   return {
-    items: state.contacts
+    items: contacts
   }
 }
 
@@ -15,7 +22,6 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onContactPress: (item) => { dispatch(toggleActive(item)) }
   }
-  // return bindActionCreators(ContactActions, dispatch)
 }
 
 const ContactPicker = connect(mapStateToProps, mapDispatchToProps)(ContactList)

--- a/HelloAgain/index.ios.js
+++ b/HelloAgain/index.ios.js
@@ -1,53 +1,6 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- * @flow
- */
+'use strict';
 
-import React, { Component } from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
+import { AppRegistry } from 'react-native';
+import HelloAgain from './containers/app';
 
-export default class HelloAgain extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.ios.js
-        </Text>
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
-    );
-  }
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
-
-AppRegistry.registerComponent('HelloAgain', () => HelloAgain);
+AppRegistry.registerComponent('HelloAgain', () => HelloAgain)

--- a/HelloAgain/store-scaffold.js
+++ b/HelloAgain/store-scaffold.js
@@ -1,0 +1,35 @@
+"use strict";
+
+// Scaffolding an initial store state to allow manual testing. Will remove this
+// module and all references once addressbook importing is implemented.
+
+// For reasons I don't understand,trying to
+//   import { CONTACT_FIXTURE } from "./__tests__/fixtures/contacts" 
+// yields an error in node, so I'm just cut-n-pasting in here, since this code
+// will go away soon.
+const CONTACT_FIXTURE = [
+    { recordID: 1, familyName: "Copernicus", givenName: "Nicolaus" },
+    { recordID: 2, familyName: "Brahe", givenName: "Tycho" },
+    { recordID: 3, familyName: "Tombaugh", givenName: "Clyde" },
+    { recordID: 4, familyName: "Herschel", givenName: "William" },
+    { recordID: 5, familyName: "Herschel", givenName: "John" },
+    { recordID: 6, familyName: "Messier", givenName: "Charles" },
+    { recordID: 7, familyName: "Leavitt", givenName: "Henrietta", middleName: "Swan" },
+    { recordID: 8, familyName: "Lalande", givenName: "Jérôme" },
+    { recordID: 9, familyName: "Herzsprung", givenName: "Ejnar" },
+    { recordID: 10, familyName: "Hubble", givenName: "Edwin" },
+    { recordID: 11, familyName: "Rubin", givenName: "Vera" },
+    { recordID: 12, familyName: "Kepler", givenName: "Johannes" },
+    { recordID: 13, familyName: "Humason", givenName: "Milton", middleName: "L." },
+    { recordID: 14, familyName: "Oort", givenName: "Jan" },
+    { recordID: 15, familyName: "Klumpke", givenName: "Dorothea" },
+    { recordID: 16, familyName: "Struve", givenName: "Gustav Wilhelm Ludvig" },
+    { recordID: 17, familyName: "Wolf", givenName: "Max" },
+]
+
+const initialFriends = {}
+CONTACT_FIXTURE.forEach((item) => {initialFriends[item.recordID] = item})
+
+const initialState = {friends: initialFriends}
+
+export default initialState

--- a/HelloAgain/store.js
+++ b/HelloAgain/store.js
@@ -1,8 +1,11 @@
 'use strict';
 
 import { createStore } from 'redux'
-import mainReducer from '../reducers'
+import mainReducer from './reducers'
 
-const store = createStore(mainReducer)
+// Purely for testing new components. Will be removed later.
+import initialState from './store-scaffold'
+
+const store = createStore(mainReducer, initialState)
 
 export default store


### PR DESCRIPTION
Add a `HelloAgain` root component. For now, it just loads some scaffolded friend data (which will be removed later) and shows them in the `ContactPicker`. 

Type `react-native run-ios` and click on the astronomers! Choose some to be your friends. 🎉 

And, yeah, this gets us back to where we were as of our first working demo this time last year... but I think it's going to go a lot faster from here.

One executive decision I made involved getting the `ContactList`'s `ListView` to update (our original Achilles heel!). Rather than have a separate contacts state, we now load the contacts out of the friends state and sort by first, then last, name. Keeping never-active contacts in the friends store makes reducer management a lot simpler, but it also means that, at some point in the future, when the friends store is persisted, these never-friends will have to be filtered out before serialization (because we really don't want to lug around the entire user's contact database).

(To clarify, this means that the difference between a _friend_ and a _contact_ is whether or not `isActive` is defined on the record in the `friends` state. If it is either `true` or `false`, then the user chose to be reminded about this contact at some point, even if they later deactivated that friend; if `isActive` is `undefined`, then the contact is by definition not a _friend_, in the parlance of this project.)

The result is that `index.ios.js` just loads the `HelloAgain` root and registers it with React Native. This may change soon. I haven't touched `index.android.js` and probably won't -- that may have to wait until we find an Android maintainer.

The other consequence is that most of this PR is test snapshot and fixture changes 🙄 

Next steps in rough priority order:

* Create a `FriendQueue` that shows the active friends in order of queue position.
* Wire up the RN Navigator(IOS) component to navigate between `FriendQueue` and `ContactPicker`
* Make it possible to manipulate the `FriendQueue` by (probably) swiping a friend
* Add redux store event logging, so that you can see a friend's contact history
* Persist the redux store (bearing in mind to filter out non-friended contacts)
* Import actual address book data
* Add a `FriendDetail` screen accessible by tapping a friend item
* Add priority levels... need to figure out how priority levels impact queue placement tho

@obra if you would be so kind?