### PR TITLE
Fix bug where a contact wasn't getting defaults set if already present

### DIFF
--- a/HelloAgain/__tests__/reducers/__snapshots__/friends.js.snap
+++ b/HelloAgain/__tests__/reducers/__snapshots__/friends.js.snap
@@ -20,6 +20,7 @@ Object {
   "50": Object {
     "isActive": false,
     "name": "Bob",
+    "rank": 1,
     "recordID": 50,
   },
 }
@@ -30,6 +31,7 @@ Object {
   "50": Object {
     "isActive": true,
     "name": "Bob",
+    "rank": 1,
     "recordID": 50,
   },
 }

--- a/HelloAgain/reducers/friends.js
+++ b/HelloAgain/reducers/friends.js
@@ -20,16 +20,17 @@ const queueTail = (state) => {
   return Math.max(0, ...ranks)
 }
 
-const defaults = (state) => {
+const defaultValues = (state) => {
   return {
-    rank: queueTail(state) + 1
+    rank: queueTail(state) + 1,
+    isActive: false
   }
 }
 
 const updateFriend = (state, update, useDefaults) => {
   let id = _id(update)
-  let existing = state[id] || (useDefaults ? defaults(state) : {})
-  let newFriend = {...existing, ...update}
+  let defaults = useDefaults ? defaultValues(state) : undefined
+  let newFriend = {...defaults, ...state[id], ...update}
   return {...state, [id]: newFriend}
 }
 


### PR DESCRIPTION
A contact already in the store but never previously active -- which will be the case for most never-friended contacts -- wasn't getting defaults set when toggled active. Fixed, and updated and confirmed the test snapshot.

@obra FYI, but I'm going to merge because I have a big PR coming