### PR TITLE
Add FriendQueue and make it the app home page.

### DIFF
--- a/HelloAgain/__tests__/components/__snapshots__/friend-list.js.snap
+++ b/HelloAgain/__tests__/components/__snapshots__/friend-list.js.snap
@@ -1,0 +1,728 @@
+exports[`test renders a list of friends 1`] = `
+<View
+  style={
+    Object {
+      "paddingTop": 64,
+    }
+  }>
+  <ScrollView
+    dataSource={
+      ListViewDataSource {
+        "items": 17,
+      }
+    }
+    initialListSize={10}
+    onContentSizeChange={[Function]}
+    onEndReachedThreshold={1000}
+    onKeyboardDidHide={undefined}
+    onKeyboardDidShow={undefined}
+    onKeyboardWillHide={undefined}
+    onKeyboardWillShow={undefined}
+    onLayout={[Function]}
+    onScroll={[Function]}
+    pageSize={1}
+    removeClippedSubviews={true}
+    renderRow={[Function]}
+    scrollEventThrottle={50}
+    scrollRenderAheadDistance={1000}
+    stickyHeaderIndices={Array []}
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "backgroundColor": "#ffffff",
+        "paddingTop": 20,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Nicolaus
+           
+          Copernicus
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Tycho
+           
+          Brahe
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Clyde
+           
+          Tombaugh
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          William
+           
+          Herschel
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          John
+           
+          Herschel
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Charles
+           
+          Messier
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Henrietta
+           
+          Leavitt
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Jérôme
+           
+          Lalande
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Ejnar
+           
+          Herzsprung
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Edwin
+           
+          Hubble
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+  </ScrollView>
+</View>
+`;

--- a/HelloAgain/__tests__/components/__snapshots__/friend.js.snap
+++ b/HelloAgain/__tests__/components/__snapshots__/friend.js.snap
@@ -1,0 +1,71 @@
+exports[`test frienders 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+      },
+      undefined,
+    ]
+  }
+  testID={undefined}>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#F5FCFF",
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-around",
+        "padding": 5,
+      }
+    }>
+    <Image
+      source={Object {}}
+      style={undefined} />
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "flex": 15,
+          "fontSize": 20,
+          "marginBottom": 5,
+          "textAlign": "left",
+        }
+      }>
+      Nicolaus
+       
+      Copernicus
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "flex": 1,
+          "fontSize": 15,
+          "marginBottom": 5,
+          "marginRight": 5,
+          "textAlign": "right",
+        }
+      }>
+      ???
+    </Text>
+  </View>
+</View>
+`;

--- a/HelloAgain/__tests__/components/friend-list.js
+++ b/HelloAgain/__tests__/components/friend-list.js
@@ -1,0 +1,13 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { CONTACT_FIXTURE } from "../fixtures/contacts"
+import FriendList from "../../components/friend-list"
+
+it('renders a list of friends', () => {
+  expect(renderer.create(
+    <FriendList items={CONTACT_FIXTURE} />
+  )).toMatchSnapshot();
+})

--- a/HelloAgain/__tests__/components/friend.js
+++ b/HelloAgain/__tests__/components/friend.js
@@ -1,0 +1,14 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import { CONTACT_FIXTURE } from "../fixtures/contacts"
+import Friend from "../../components/friend"
+
+it('frienders', () => {
+  let fixture = CONTACT_FIXTURE[0]
+  expect(renderer.create(
+    <Friend item={fixture} />
+  )).toMatchSnapshot();
+})

--- a/HelloAgain/__tests__/containers/__snapshots__/friend-queue.js.snap
+++ b/HelloAgain/__tests__/containers/__snapshots__/friend-queue.js.snap
@@ -1,0 +1,776 @@
+exports[`test renders a list of friends 1`] = `
+<View
+  style={
+    Object {
+      "paddingTop": 64,
+    }
+  }>
+  <ScrollView
+    dataSource={
+      ListViewDataSource {
+        "items": 17,
+      }
+    }
+    initialListSize={10}
+    onContentSizeChange={[Function]}
+    onEndReachedThreshold={1000}
+    onKeyboardDidHide={undefined}
+    onKeyboardDidShow={undefined}
+    onKeyboardWillHide={undefined}
+    onKeyboardWillShow={undefined}
+    onLayout={[Function]}
+    onScroll={[Function]}
+    pageSize={1}
+    removeClippedSubviews={true}
+    renderRow={[Function]}
+    scrollEventThrottle={50}
+    scrollRenderAheadDistance={1000}
+    stickyHeaderIndices={Array []}
+    style={
+      Object {
+        "alignSelf": "stretch",
+        "backgroundColor": "#ffffff",
+        "paddingTop": 20,
+      }
+    }>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Nicolaus
+           
+          Copernicus
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Max
+           
+          Wolf
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Clyde
+           
+          Tombaugh
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          William
+           
+          Herschel
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          John
+           
+          Herschel
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Charles
+           
+          Messier
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Henrietta
+           
+          Leavitt
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Jérôme
+           
+          Lalande
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Tycho
+           
+          Brahe
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#F5FCFF",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-around",
+            "padding": 5,
+          }
+        }>
+        <Image
+          source={Object {}}
+          style={undefined} />
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 15,
+              "fontSize": 20,
+              "marginBottom": 5,
+              "textAlign": "left",
+            }
+          }>
+          Edwin
+           
+          Hubble
+        </Text>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "flex": 1,
+              "fontSize": 15,
+              "marginBottom": 5,
+              "marginRight": 5,
+              "textAlign": "right",
+            }
+          }>
+          ???
+        </Text>
+      </View>
+    </View>
+  </ScrollView>
+</View>
+`;
+
+exports[`test sorts and filters a list of friends from the store 1`] = `
+Array [
+  Object {
+    "familyName": "Struve",
+    "givenName": "Gustav Wilhelm Ludvig",
+    "isActive": true,
+    "rank": 1,
+    "recordID": 16,
+  },
+  Object {
+    "familyName": "Copernicus",
+    "givenName": "Nicolaus",
+    "isActive": true,
+    "rank": 2,
+    "recordID": 1,
+  },
+  Object {
+    "familyName": "Leavitt",
+    "givenName": "Henrietta",
+    "isActive": true,
+    "middleName": "Swan",
+    "rank": 3,
+    "recordID": 7,
+  },
+  Object {
+    "familyName": "Herschel",
+    "givenName": "William",
+    "isActive": true,
+    "rank": 4,
+    "recordID": 4,
+  },
+  Object {
+    "familyName": "Klumpke",
+    "givenName": "Dorothea",
+    "isActive": true,
+    "rank": 5,
+    "recordID": 15,
+  },
+  Object {
+    "familyName": "Herzsprung",
+    "givenName": "Ejnar",
+    "isActive": true,
+    "rank": 6,
+    "recordID": 9,
+  },
+]
+`;

--- a/HelloAgain/__tests__/containers/contact-picker.js
+++ b/HelloAgain/__tests__/containers/contact-picker.js
@@ -7,7 +7,7 @@ import configureStore from 'redux-mock-store'
 
 import { TOGGLE_ACTIVE } from "../../actions/types"
 import ContactPicker from "../../containers/contact-picker"
-import FRIENDS_FIXTURE from "../fixtures/friends"
+import { FRIENDS_FIXTURE } from "../fixtures/friends"
 
 const mockStore = configureStore([])
 const store = mockStore({friends: FRIENDS_FIXTURE})

--- a/HelloAgain/__tests__/containers/friend-queue.js
+++ b/HelloAgain/__tests__/containers/friend-queue.js
@@ -1,0 +1,46 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme'
+import configureStore from 'redux-mock-store'
+
+import { toggleActive } from "../../actions/contact"
+import FriendQueue from "../../containers/friend-queue"
+import { copyFriendsFixture } from "../fixtures/friends"
+
+const mockStore = configureStore([])
+
+it('renders a list of friends', () => {
+  const fixture = copyFriendsFixture()
+  Object.values(fixture).forEach((f) => {f.isActive = true})
+  const store = mockStore({friends: fixture})
+  expect(renderer.create(
+    <FriendQueue store={store} />
+  )).toMatchSnapshot()
+})
+
+it('sorts and filters a list of friends from the store', () => {
+  // Sort friends by descending length of name, because why not
+  const rankedFriends = Object.values(copyFriendsFixture())
+  rankedFriends.sort((a, b) => {
+    return (b.givenName + b.familyName).length - (a.givenName + a.familyName).length
+  })
+  // Pick six friends and rank them
+  const initialFriends = {}
+  let rank = 1
+  rankedFriends.slice(0, 6).forEach((f) => {
+    initialFriends[f.recordID] = {...f, rank: rank++, isActive: true}
+  })
+  // Copy the others but don't set them active
+  rankedFriends.slice(6).forEach((f) => {
+    initialFriends[f.recordID] = f
+  })
+  const store = mockStore({friends: initialFriends})
+  // Now render and make sure they're sorted and filtered accordingly
+  const wrapper = shallow(
+    <FriendQueue store={store} />
+  )
+  const items = wrapper.prop("items")
+  expect(items).toMatchSnapshot()
+})

--- a/HelloAgain/__tests__/fixtures/friends.js
+++ b/HelloAgain/__tests__/fixtures/friends.js
@@ -2,7 +2,10 @@
 
 import {CONTACT_FIXTURE} from "./contacts"
 
-const FRIENDS_FIXTURE = {}
-CONTACT_FIXTURE.forEach((item) => {FRIENDS_FIXTURE[item.recordID] = item})
+export const copyFriendsFixture = () => {
+  const fixture = {}
+  CONTACT_FIXTURE.forEach((item) => {fixture[item.recordID] = {...item}})
+  return fixture
+}
 
-export default FRIENDS_FIXTURE
+export const FRIENDS_FIXTURE = copyFriendsFixture()

--- a/HelloAgain/components/friend-list.js
+++ b/HelloAgain/components/friend-list.js
@@ -1,0 +1,65 @@
+'use strict';
+
+import React, { Component } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet
+} from 'react-native'
+
+import ContactList from './contact-list'
+import Friend from './friend'
+
+export default class FriendList extends ContactList {
+  renderContact(rowData) {
+    return (
+      <Friend item={rowData} />
+    )
+  }
+
+  render() {
+    if (this.props.items && this.props.items.length > 0) {
+      // See note about paddingTop below... I have _no_ idea why this is
+      // necessary here but not in ContactPicker -> ContactList.
+      return (
+        <View style={{paddingTop: 64}}>
+          {super.render()}
+        </View>
+      )
+    }
+    return (
+      <View style={styles.welcomeView}>
+        <Text style={styles.welcomeHeader}>
+          Welcome!
+        </Text>
+        <Text style={styles.welcomeContent}>
+          Tap the icon in the upper right to start adding friends from your contacts.
+        </Text>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  welcomeView: {
+    // Extensive discussion here: https://github.com/facebook/react-native/issues/759
+    // ... about how paddingTop: 64 is basically magic.
+    paddingTop: 64,
+    flexDirection: "column",
+    flex: 1,
+    alignSelf: 'center',
+    width: 200,
+    margin: 64
+  },
+  welcomeHeader: {
+    fontSize: 24,
+    fontWeight: "bold",
+    textAlign: "center",
+    flex: 1
+  },
+  welcomeContent: {
+    fontSize: 14,
+    textAlign: "justify",
+    flex: 5
+  }
+})

--- a/HelloAgain/components/friend.js
+++ b/HelloAgain/components/friend.js
@@ -1,0 +1,59 @@
+'use strict';
+
+import React, { Component } from 'react';
+import {
+  Text,
+  View,
+  StyleSheet,
+  TouchableHighlight,
+  Image
+} from 'react-native'
+
+export default class Friend extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    const item = this.props.item;
+    var imageSource = {};
+    if (item.thumbnailPath) {
+      imageSource.uri = item.thumbnailPath
+    }
+    // FIXME: showing the item rank is a placeholder -- replace later
+    return (
+      <TouchableHighlight>
+        <View style={styles.contactRow}>
+          <Image style={styles.contactPicture} source={imageSource} />
+          <Text style={styles.contactName}>{item.givenName} {item.familyName}</Text>
+          <Text style={styles.contactRank}>{item.rank || "???"}</Text>
+        </View>
+      </TouchableHighlight>
+    )
+  }
+}
+
+// This really wants to be refactored somehow with the contact styles
+const styles = StyleSheet.create({
+  contactRow: {
+    flex: 1,
+    padding: 5,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF'
+  },
+  contactName: {
+    textAlign: 'left',
+    fontSize: 20,
+    flex: 15,
+    marginBottom: 5
+  },
+  contactRank: {
+    textAlign: 'right',
+    marginRight: 5,
+    fontSize: 15,
+    flex: 1,
+    marginBottom: 5
+  }  
+})

--- a/HelloAgain/containers/app.js
+++ b/HelloAgain/containers/app.js
@@ -4,31 +4,28 @@ import { NavigatorIOS } from 'react-native';
 
 import store from '../store'
 import ContactPicker from './contact-picker'
+import FriendQueue from './friend-queue'
 
 export default class HelloAgain extends Component {
   constructor(props) {
     super(props)
   }
 
-  /*
-   * stashing this here for future use:
-   *
-   pickContacts() {
-      const nav = this.refs.nav;
-      nav.push({
-        title: "Add Friends",
-        component: ContactPicker,
-        rightButtonTitle: null,
-        leftButtonTitle: "Back",
-        onLeftButtonPress: () => { nav.pop() }
-      })
-    }
-  */
+  pickContacts() {
+    const nav = this.refs.nav;
+    nav.push({
+      title: "Add Friends",
+      component: ContactPicker,
+      rightButtonTitle: null,
+      leftButtonTitle: "⬅️",
+      onLeftButtonPress: () => { nav.pop() }
+    })
+  }
 
   render() {
     const initialRoute = {
       title: "Hello Again!",
-      component: ContactPicker
+      component: FriendQueue
     }
     return (
       <Provider store={store}>
@@ -38,7 +35,7 @@ export default class HelloAgain extends Component {
           initialRoute={initialRoute}
           rightButtonTitle="👥"
           leftButtonTitle="⚙"
-          /* onRightButtonPress={this.pickContacts} */
+          onRightButtonPress={this.pickContacts.bind(this)}
         />
       </Provider>
     );

--- a/HelloAgain/containers/friend-queue.js
+++ b/HelloAgain/containers/friend-queue.js
@@ -1,0 +1,23 @@
+'use strict'
+
+import React from 'react';
+import { connect } from 'react-redux'
+import FriendList from '../components/friend-list'
+import Friend from '../components/friend'
+
+const mapStateToProps = (state) => {
+  // Collect active friends
+  const friends = Object.values(state.friends).filter((f) => f.isActive)
+  // Sort by queue rank
+  friends.sort((a, b) => a.rank - b.rank)
+  return {
+    items: friends
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {}
+}
+
+const FriendQueue = connect(mapStateToProps, mapDispatchToProps)(FriendList)
+export default FriendQueue 


### PR DESCRIPTION
This branch has quite a bit of stuff, but it's sort of all of a piece:

* A `Friend` component, by analogy with `Contact`, for displaying different information related to a given friend in the Friend Queue.
* A `FriendList` component that subclasses `ContactList`, and either
  * swaps in `Friend` for `Contact` as the list display item (these don't do anything yet, and the display of queue rank number is purely a placeholder)
  * if no friends have been selected yet, displays a nice welcome message instead
* A `FriendQueue` container that populates a `FriendList` with active friends, sorted by rank.
* Finally, the `FriendQueue` is wired up as the initial scene in the navigator, and the upper right hand button is wired to the `ContactPicker` as expected

All this needs is persistence, swipe friend to mark as contacted, and actual addressbook integration, and we would actually have a useful working app.

N.B. there's one bit of weirdness where I have to throw in padding on the `FriendQueue` screen to keep it from getting rendered under the navigation bar, but I _don't_ have to do that on the `ContactPicker`. I've dealt with it in kind of a hacky way, but I'm still scratching my head over why.

@obra -- as usual, scroll past the snapshots. The actual meat of the PR is hopefully pretty straightforward.

/me yawns