### PR TITLE
Add friend detail view, accessible from friend queue via list item press.

### DIFF
--- a/HelloAgain/__tests__/components/__snapshots__/friend-detail.js.snap
+++ b/HelloAgain/__tests__/components/__snapshots__/friend-detail.js.snap
@@ -1,0 +1,103 @@
+exports[`test frienders 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "flex": 1,
+      "flexDirection": "column",
+      "margin": 64,
+      "paddingTop": 64,
+      "width": 200,
+    }
+  }>
+  <Image
+    source={Object {}}
+    style={
+      Object {
+        "borderColor": "grey",
+        "borderWidth": 1,
+        "flex": 1,
+        "height": 128,
+        "margin": 32,
+        "width": 128,
+      }
+    } />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "flex": 1,
+        "fontSize": 24,
+        "fontWeight": "bold",
+        "textAlign": "center",
+      }
+    }>
+    Nicolaus
+     
+    Copernicus
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "flex": 1,
+        "fontSize": 14,
+        "textAlign": "justify",
+      }
+    }>
+    Last contacted: 
+    unknown
+  </Text>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel={undefined}
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+    testID={undefined}>
+    <View
+      style={
+        Array [
+          Object {},
+        ]
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "#0C42FD",
+              "fontSize": 18,
+              "padding": 8,
+              "textAlign": "center",
+            },
+          ]
+        }>
+        Contacted
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/HelloAgain/__tests__/components/friend-detail.js
+++ b/HelloAgain/__tests__/components/friend-detail.js
@@ -1,0 +1,30 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import sinon from 'sinon'
+import { shallow } from 'enzyme'
+
+
+import { CONTACT_FIXTURE } from "../fixtures/contacts"
+import FriendDetail from "../../components/friend-detail"
+
+it('frienders', () => {
+  let fixture = CONTACT_FIXTURE[0]
+  expect(renderer.create(
+    <FriendDetail item={fixture} />
+  )).toMatchSnapshot();
+})
+
+it('responds when marked contacted', () => {
+  const fixture = CONTACT_FIXTURE[0]
+  const onPress = sinon.spy()
+  const closeDetail = sinon.spy()
+  const wrapper = shallow(
+    <FriendDetail item={fixture} onContactedPress={onPress} closeDetail={closeDetail} />
+  )
+  wrapper.find("Button").simulate("press")
+  expect(onPress.calledOnce).toBe(true)
+  expect(onPress.args[0][0]).toMatchObject(fixture)
+  expect(closeDetail.calledOnce).toBe(true)
+})

--- a/HelloAgain/__tests__/containers/__snapshots__/friend-view.js.snap
+++ b/HelloAgain/__tests__/containers/__snapshots__/friend-view.js.snap
@@ -1,0 +1,103 @@
+exports[`test frienders 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "flex": 1,
+      "flexDirection": "column",
+      "margin": 64,
+      "paddingTop": 64,
+      "width": 200,
+    }
+  }>
+  <Image
+    source={Object {}}
+    style={
+      Object {
+        "borderColor": "grey",
+        "borderWidth": 1,
+        "flex": 1,
+        "height": 128,
+        "margin": 32,
+        "width": 128,
+      }
+    } />
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "flex": 1,
+        "fontSize": 24,
+        "fontWeight": "bold",
+        "textAlign": "center",
+      }
+    }>
+    Nicolaus
+     
+    Copernicus
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "flex": 1,
+        "fontSize": 14,
+        "textAlign": "justify",
+      }
+    }>
+    Last contacted: 
+    unknown
+  </Text>
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel={undefined}
+    accessibilityTraits={
+      Array [
+        "button",
+      ]
+    }
+    accessible={true}
+    hitSlop={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+    testID={undefined}>
+    <View
+      style={
+        Array [
+          Object {},
+        ]
+      }>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Array [
+            Object {
+              "color": "#0C42FD",
+              "fontSize": 18,
+              "padding": 8,
+              "textAlign": "center",
+            },
+          ]
+        }>
+        Contacted
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/HelloAgain/__tests__/containers/friend-view.js
+++ b/HelloAgain/__tests__/containers/friend-view.js
@@ -1,0 +1,19 @@
+'use strict'
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import configureStore from 'redux-mock-store'
+
+import { copyFriendsFixture } from "../fixtures/friends"
+import FriendView from "../../containers/friend-view"
+
+const mockStore = configureStore([])
+
+it('frienders', () => {
+  const fixture = copyFriendsFixture()
+  Object.values(fixture).forEach((f) => {f.isActive = true})
+  const store = mockStore({friends: fixture})
+  expect(renderer.create(
+    <FriendView store={store} item={fixture["1"]} />
+  )).toMatchSnapshot();
+})

--- a/HelloAgain/components/friend-detail.js
+++ b/HelloAgain/components/friend-detail.js
@@ -1,0 +1,69 @@
+'use strict';
+
+import React, { Component } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Image,
+  Button
+} from 'react-native'
+
+export default class FriendDetail extends Component {
+  render() {
+    const item = this.props.item;
+    var imageSource = {};
+    if (item.thumbnailPath) {
+      imageSource.uri = item.thumbnailPath
+    }
+    return (
+        <View style={styles.friendDetail}>
+          <Image style={styles.friendPicture} source={imageSource} />
+          <Text style={styles.friendName}>{item.givenName} {item.familyName}</Text>
+          <Text style={styles.friendContent}>Last contacted: {item.lastContactedAt || "unknown"}</Text>
+          <Button 
+            style={styles.contactedButton}
+            onPress={_ => {
+              this.props.onContactedPress(item)
+              this.props.closeDetail()
+            }}
+            title="Contacted" />
+        </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  friendDetail: {
+    // Extensive discussion here: https://github.com/facebook/react-native/issues/759
+    // ... about how paddingTop: 64 is basically magic.
+    paddingTop: 64,
+    flexDirection: "column",
+    flex: 1,
+    alignSelf: 'center',
+    width: 200,
+    margin: 64
+  },
+  friendPicture: {
+    height: 128,
+    width: 128,
+    margin: 32,
+    borderWidth: 1,
+    borderColor: "grey",
+    flex: 1
+  },
+  friendName: {
+    fontSize: 24,
+    fontWeight: "bold",
+    textAlign: "center",
+    flex: 1
+  },
+  friendContent: {
+    fontSize: 14,
+    textAlign: "justify",
+    flex: 1
+  },
+  contactedButton: {
+    flex: 1
+  }
+})

--- a/HelloAgain/components/friend-list.js
+++ b/HelloAgain/components/friend-list.js
@@ -13,7 +13,7 @@ import Friend from './friend'
 export default class FriendList extends ContactList {
   renderContact(rowData) {
     return (
-      <Friend item={rowData} />
+      <Friend item={rowData} onPress={this.props.onContactPress}/>
     )
   }
 

--- a/HelloAgain/components/friend.js
+++ b/HelloAgain/components/friend.js
@@ -22,7 +22,7 @@ export default class Friend extends Component {
     }
     // FIXME: showing the item rank is a placeholder -- replace later
     return (
-      <TouchableHighlight>
+      <TouchableHighlight onPress={() => this.props.onPress(item)}>
         <View style={styles.contactRow}>
           <Image style={styles.contactPicture} source={imageSource} />
           <Text style={styles.contactName}>{item.givenName} {item.familyName}</Text>

--- a/HelloAgain/containers/app.js
+++ b/HelloAgain/containers/app.js
@@ -5,6 +5,7 @@ import { NavigatorIOS } from 'react-native';
 import store from '../store'
 import ContactPicker from './contact-picker'
 import FriendQueue from './friend-queue'
+import FriendView from './friend-view'
 
 export default class HelloAgain extends Component {
   constructor(props) {
@@ -22,10 +23,29 @@ export default class HelloAgain extends Component {
     })
   }
 
+  viewFriend(item) {
+    const nav = this.refs.nav
+    const popNav = _ => { nav.pop() }
+    nav.push({
+      component: FriendView,
+      title: 'Friend Detail',
+      passProps: {
+        item,
+        closeDetail: popNav
+      },
+      rightButtonTitle: null,
+      leftButtonTitle: "⬅️",
+      onLeftButtonPress: popNav
+    })
+  }
+
   render() {
     const initialRoute = {
       title: "Hello Again!",
-      component: FriendQueue
+      component: FriendQueue,
+      passProps: {
+        onContactPress: this.viewFriend.bind(this)
+      }
     }
     return (
       <Provider store={store}>

--- a/HelloAgain/containers/friend-view.js
+++ b/HelloAgain/containers/friend-view.js
@@ -1,0 +1,18 @@
+'use strict'
+
+import { connect } from 'react-redux'
+import FriendDetail from '../components/friend-detail'
+
+const mapStateToProps = (state) => {
+  return {
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    onContactedPress: (item) => {}
+  }
+}
+
+const FriendView = connect(mapStateToProps, mapDispatchToProps)(FriendDetail)
+export default FriendView


### PR DESCRIPTION
Now we're at the place where React Native + Redux really starts to shine -- adding a friend detail view was almost surprisingly easy.

Current status: You can add friends in the contact picker, go back to the friend queue, and press on any friend to go to their detail view. The detail view has a "Contacted" button, which, if pressed, does nothing (aside from taking you back to the queue view).

Making this button do something will be in the next PR, at which point we will have a mockup of a fully-working app 😮 

(as usual, scroll past the test snapshots to see the actual code)

@obra please and thank you