### PR TITLE
Mark a user as contacted in the friend detail view.

### DIFF
--- a/HelloAgain/__tests__/actions/__snapshots__/friend.js.snap
+++ b/HelloAgain/__tests__/actions/__snapshots__/friend.js.snap
@@ -1,3 +1,12 @@
+exports[`markAsContacted should return an action 1`] = `
+Object {
+  "friend": Object {
+    "name": "Bob",
+  },
+  "type": "MARK_AS_CONTACTED",
+}
+`;
+
 exports[`updateFriend should return an action 1`] = `
 Object {
   "friend": Object {

--- a/HelloAgain/__tests__/actions/friend.js
+++ b/HelloAgain/__tests__/actions/friend.js
@@ -2,11 +2,20 @@
 
 import * as actions from '../../actions/friend'
 
+let bob = {name: "Bob"};
+
 describe('updateFriend', () => {
   it('should return an action', () => {
-    let bob = {name: "Bob"};
     expect(
       actions.updateFriend(bob)
+    ).toMatchSnapshot()
+  })
+})
+
+describe('markAsContacted', () => {
+  it('should return an action', () => {
+    expect(
+      actions.markAsContacted(bob)
     ).toMatchSnapshot()
   })
 })

--- a/HelloAgain/__tests__/containers/__snapshots__/friend-view.js.snap
+++ b/HelloAgain/__tests__/containers/__snapshots__/friend-view.js.snap
@@ -101,3 +101,16 @@ exports[`test frienders 1`] = `
   </View>
 </View>
 `;
+
+exports[`test marks a friend contacted 1`] = `
+Array [
+  Object {
+    "friend": Object {
+      "familyName": "Copernicus",
+      "givenName": "Nicolaus",
+      "recordID": 1,
+    },
+    "type": "MARK_AS_CONTACTED",
+  },
+]
+`;

--- a/HelloAgain/__tests__/containers/friend-view.js
+++ b/HelloAgain/__tests__/containers/friend-view.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme'
 import configureStore from 'redux-mock-store'
 
 import { copyFriendsFixture } from "../fixtures/friends"
@@ -16,4 +17,16 @@ it('frienders', () => {
   expect(renderer.create(
     <FriendView store={store} item={fixture["1"]} />
   )).toMatchSnapshot();
+})
+
+it('marks a friend contacted', () => {
+  const fixture = copyFriendsFixture()
+  const store = mockStore({friends: fixture})
+  const friend = fixture["1"]
+  const wrapper = shallow(
+    <FriendView store={store} item={friend} />
+  )
+  wrapper.props().onContactedPress(friend)
+  const actions = store.getActions()
+  expect(actions).toMatchSnapshot()
 })

--- a/HelloAgain/__tests__/reducers/friends.js
+++ b/HelloAgain/__tests__/reducers/friends.js
@@ -39,6 +39,18 @@ describe('friends reducer', () => {
     })
   })
 
+  describe('markAsContacted action', () => {
+    let initialState = friends(
+      undefined,
+      actions.updateFriend({...bob, rank: 12})
+    )
+    it('should update rank and contactedAt', () => {
+      let newState = friends(initialState, actions.markAsContacted(bob))
+      expect(newState[bob.recordID].contactedAt).toBeTruthy()
+      expect(newState[bob.recordID].rank).toEqual(13)
+    })
+  })
+
   describe('toggleActive action', () => {
     it('should toggle a new friend active and set default', () => {
       let state = friends(undefined, contactActions.toggleActive(bob))

--- a/HelloAgain/actions/friend.js
+++ b/HelloAgain/actions/friend.js
@@ -1,9 +1,14 @@
 'use strict'
 
 import {
-  UPDATE_FRIEND
+  UPDATE_FRIEND,
+  MARK_AS_CONTACTED
 } from './types'
 
 export const updateFriend = (friend) => {
   return { type: UPDATE_FRIEND, friend: friend }
+}
+
+export const markAsContacted = (friend) => {
+  return { type: MARK_AS_CONTACTED, friend: friend }
 }

--- a/HelloAgain/actions/types.js
+++ b/HelloAgain/actions/types.js
@@ -5,3 +5,4 @@ export const TOGGLE_ACTIVE = 'TOGGLE_ACTIVE'
 
 // Friends
 export const UPDATE_FRIEND = 'UPDATE_FRIEND'
+export const MARK_AS_CONTACTED = 'MARK_AS_CONTACTED'

--- a/HelloAgain/components/friend-detail.js
+++ b/HelloAgain/components/friend-detail.js
@@ -16,11 +16,12 @@ export default class FriendDetail extends Component {
     if (item.thumbnailPath) {
       imageSource.uri = item.thumbnailPath
     }
+    let contactedAt = item.contactedAt ? Date(item.contactedAt).toString() : "unknown"
     return (
         <View style={styles.friendDetail}>
           <Image style={styles.friendPicture} source={imageSource} />
           <Text style={styles.friendName}>{item.givenName} {item.familyName}</Text>
-          <Text style={styles.friendContent}>Last contacted: {item.lastContactedAt || "unknown"}</Text>
+          <Text style={styles.friendContent}>Last contacted: {contactedAt}</Text>
           <Button 
             style={styles.contactedButton}
             onPress={_ => {

--- a/HelloAgain/containers/friend-view.js
+++ b/HelloAgain/containers/friend-view.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import { connect } from 'react-redux'
+import { markAsContacted } from '../actions/friend'
 import FriendDetail from '../components/friend-detail'
 
 const mapStateToProps = (state) => {
@@ -10,7 +11,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onContactedPress: (item) => {}
+    onContactedPress: item => dispatch(markAsContacted(item))
   }
 }
 

--- a/HelloAgain/reducers/friends.js
+++ b/HelloAgain/reducers/friends.js
@@ -2,7 +2,8 @@
 
 import { 
   UPDATE_FRIEND,
-  TOGGLE_ACTIVE
+  TOGGLE_ACTIVE,
+  MARK_AS_CONTACTED
 } from '../actions/types';
 
 const _id = (friend) => {
@@ -27,6 +28,14 @@ const defaultValues = (state) => {
   }
 }
 
+const markContacted = (state, friend) => {
+  return {
+    ...friend,
+    rank: queueTail(state) + 1,
+    contactedAt: Date.now()
+  }
+}
+
 const updateFriend = (state, update, useDefaults) => {
   let id = _id(update)
   let defaults = useDefaults ? defaultValues(state) : undefined
@@ -42,6 +51,9 @@ const friends = (state = {}, action) => {
       let update = {...action.friend, isActive: !isActive}
       // Set default values (if needed) when toggling a friend
       return updateFriend(state, update, true)
+    case MARK_AS_CONTACTED:
+      let asContacted = markContacted(state, action.friend)
+      return updateFriend(state, asContacted)
     case UPDATE_FRIEND:
       return updateFriend(state, action.friend)
     default:


### PR DESCRIPTION
By pushing the contacted button. Updates the `contactedAt` property with the current UNIX timestamp, and moves the friend to the bottom of the queue! 🎊 

At this point, we have an almost completely working app, minus persistence and addressbook integration.

@obra thanks in advance