### PR TITLE
Add native contact integration.

### DIFF
--- a/HelloAgain/__tests__/actions/__snapshots__/contact-import.js.snap
+++ b/HelloAgain/__tests__/actions/__snapshots__/contact-import.js.snap
@@ -1,0 +1,19 @@
+exports[`contactLoadFailed should return an action 1`] = `
+Object {
+  "error": "no idea why not",
+  "type": "CONTACT_LOAD_FAILED",
+}
+`;
+
+exports[`contactsLoaded should return an action 1`] = `
+Object {
+  "contacts": Array [
+    Object {
+      "name": "Bob",
+    },
+  ],
+  "type": "CONTACTS_LOADED",
+}
+`;
+
+exports[`loadNativeContacts should return a thunk 1`] = `[Function]`;

--- a/HelloAgain/__tests__/actions/contact-import.js
+++ b/HelloAgain/__tests__/actions/contact-import.js
@@ -1,0 +1,29 @@
+'use strict';
+
+import * as actions from '../../actions/contact-import'
+
+let bob = {name: "Bob"};
+
+describe('contactsLoaded', () => {
+  it('should return an action', () => {
+    expect(
+      actions.contactsLoaded([bob])
+    ).toMatchSnapshot()
+  })
+})
+
+describe('contactLoadFailed', () => {
+  it('should return an action', () => {
+    expect(
+      actions.contactLoadFailed("no idea why not")
+    ).toMatchSnapshot()
+  })
+})
+
+describe('loadNativeContacts', () => {
+  it('should return a thunk', () => {
+    expect(
+      actions.loadNativeContacts()
+    ).toMatchSnapshot()
+  })
+})

--- a/HelloAgain/__tests__/reducers/__snapshots__/contact-import.js.snap
+++ b/HelloAgain/__tests__/reducers/__snapshots__/contact-import.js.snap
@@ -1,0 +1,13 @@
+exports[`contactImport reducer should record failed import 1`] = `
+Object {
+  "error": "no idea why not",
+  "loaded": false,
+}
+`;
+
+exports[`contactImport reducer should record successful import 1`] = `
+Object {
+  "count": 17,
+  "loaded": true,
+}
+`;

--- a/HelloAgain/__tests__/reducers/contact-import.js
+++ b/HelloAgain/__tests__/reducers/contact-import.js
@@ -1,0 +1,25 @@
+'use strict'
+
+import contactImport from '../../reducers/contact-import'
+import * as actions from '../../actions/contact-import'
+import { CONTACT_FIXTURE } from '../fixtures/contacts'
+
+describe('contactImport reducer', () => {
+  let initialState = contactImport(undefined, {})
+
+  it('should return an initial state', () => {
+    expect(initialState).toEqual({})
+  })
+
+  it('should record successful import', () => {
+    expect(
+      contactImport(initialState, actions.contactsLoaded(CONTACT_FIXTURE))
+    ).toMatchSnapshot()
+  })
+
+  it('should record failed import', () => {
+    expect(
+      contactImport(initialState, actions.contactLoadFailed("no idea why not"))
+    ).toMatchSnapshot()
+  })
+})

--- a/HelloAgain/actions/contact-import.js
+++ b/HelloAgain/actions/contact-import.js
@@ -1,0 +1,29 @@
+'use strict'
+
+import Contacts from 'react-native-contacts'
+
+import {
+  CONTACTS_LOADED, CONTACT_LOAD_FAILED
+} from './types';
+
+export const contactsLoaded = (contacts) => {
+  return {type: CONTACTS_LOADED, contacts: contacts}
+}
+
+export const contactLoadFailed = (error) => {
+  return {type: CONTACT_LOAD_FAILED, error: error}
+}
+
+export const loadNativeContacts = () => {
+  const loadContacts = new Promise((resolve, reject) => {
+    Contacts.getAll((err, contacts) => {
+      err ? reject(err) : resolve(contacts)
+    })
+  })
+  return dispatch => {
+    loadContacts.then(
+      contacts => { dispatch(contactsLoaded(contacts)) },
+      error => { dispatch(contactLoadFailed(error)) }
+    )
+  }
+}

--- a/HelloAgain/actions/types.js
+++ b/HelloAgain/actions/types.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// Native contact import
+export const CONTACTS_LOADED = 'CONTACTS_LOADED'
+export const CONTACT_LOAD_FAILED = 'CONTACT_LOAD_FAILED'
+
 // Contacts
 export const TOGGLE_ACTIVE = 'TOGGLE_ACTIVE'
 

--- a/HelloAgain/containers/app.js
+++ b/HelloAgain/containers/app.js
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux'
 import { NavigatorIOS } from 'react-native';
 
 import store from '../store'
+import { loadNativeContacts } from '../actions/contact-import'
 import ContactPicker from './contact-picker'
 import FriendQueue from './friend-queue'
 import FriendView from './friend-view'
@@ -10,6 +11,10 @@ import FriendView from './friend-view'
 export default class HelloAgain extends Component {
   constructor(props) {
     super(props)
+  }
+
+  componentWillMount() {
+    store.dispatch(loadNativeContacts())
   }
 
   pickContacts() {

--- a/HelloAgain/ios/HelloAgain.xcodeproj/project.pbxproj
+++ b/HelloAgain/ios/HelloAgain.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		520CCDAD1E2DC0B200FD6FDC /* libRCTContacts.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 520CCD961E2DC09000FD6FDC /* libRCTContacts.a */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 /* End PBXBuildFile section */
@@ -181,6 +182,13 @@
 			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
 			remoteInfo = "jschelpers-tvOS";
 		};
+		520CCD951E2DC09000FD6FDC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 520CCD8E1E2DC09000FD6FDC /* RCTContacts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 1441618E1BD0A79300FA4F59;
+			remoteInfo = RCTContacts;
+		};
 		5E9157321DD0AC6500FF2AA8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
@@ -231,6 +239,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloAgain/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = HelloAgain/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		520CCD8E1E2DC09000FD6FDC /* RCTContacts.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTContacts.xcodeproj; path = "../node_modules/react-native-contacts/ios/RCTContacts.xcodeproj"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
@@ -249,6 +258,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				520CCDAD1E2DC0B200FD6FDC /* libRCTContacts.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
@@ -372,6 +382,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		520CCD8F1E2DC09000FD6FDC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				520CCD961E2DC09000FD6FDC /* libRCTContacts.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		5E91572E1DD0AC6500FF2AA8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -393,6 +411,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				520CCD8E1E2DC09000FD6FDC /* RCTContacts.xcodeproj */,
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
@@ -511,6 +530,10 @@
 				{
 					ProductGroup = 5E91572E1DD0AC6500FF2AA8 /* Products */;
 					ProjectRef = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
+				},
+				{
+					ProductGroup = 520CCD8F1E2DC09000FD6FDC /* Products */;
+					ProjectRef = 520CCD8E1E2DC09000FD6FDC /* RCTContacts.xcodeproj */;
 				},
 				{
 					ProductGroup = 00C302B61ABCB90400DB3ED1 /* Products */;
@@ -703,6 +726,13 @@
 			fileType = archive.ar;
 			path = libjschelpers.a;
 			remoteRef = 3DAD3EAE1DF850E9000B6D8A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		520CCD961E2DC09000FD6FDC /* libRCTContacts.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTContacts.a;
+			remoteRef = 520CCD951E2DC09000FD6FDC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */ = {

--- a/HelloAgain/ios/HelloAgain/Info.plist
+++ b/HelloAgain/ios/HelloAgain/Info.plist
@@ -36,10 +36,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<key>NSContactsUsageDescription</key>
+	<string>Allows HelloAgain to choose friends to stay in touch with from your contacts.</string>
 	<key>NSAppTransportSecurity</key>
-	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>

--- a/HelloAgain/package.json
+++ b/HelloAgain/package.json
@@ -11,7 +11,8 @@
     "react-native": "0.40.0",
     "react-native-contacts": "^0.7.1",
     "react-redux": "^5.0.2",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "redux-thunk": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/HelloAgain/package.json
+++ b/HelloAgain/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "react": "15.4.2",
     "react-native": "0.40.0",
+    "react-native-contacts": "^0.7.1",
     "react-redux": "^5.0.2",
     "redux": "^3.6.0"
   },

--- a/HelloAgain/reducers/contact-import.js
+++ b/HelloAgain/reducers/contact-import.js
@@ -1,0 +1,18 @@
+'use strict'
+
+import {
+  CONTACTS_LOADED, CONTACT_LOAD_FAILED
+} from '../actions/types';
+
+const contactImport = (state = {}, action) => {
+  switch (action.type) {
+    case CONTACTS_LOADED:
+      return {...state, count: action.contacts.length, loaded: true}
+    case CONTACT_LOAD_FAILED:
+      return {...state, error: action.error, loaded: false}
+    default:
+      return state
+  }
+}
+
+export default contactImport

--- a/HelloAgain/reducers/friends.js
+++ b/HelloAgain/reducers/friends.js
@@ -3,6 +3,7 @@
 import { 
   UPDATE_FRIEND,
   TOGGLE_ACTIVE,
+  CONTACTS_LOADED,
   MARK_AS_CONTACTED
 } from '../actions/types';
 
@@ -43,8 +44,19 @@ const updateFriend = (state, update, useDefaults) => {
   return {...state, [id]: newFriend}
 }
 
+const importContacts = (state, contacts) => {
+  let newState = {...state}
+  contacts.forEach((item) => {
+    let id = _id(item)
+    newState[id] = {...item, ...state[id]}
+  })
+  return newState
+}
+
 const friends = (state = {}, action) => {
   switch (action.type) {
+    case CONTACTS_LOADED:
+      return importContacts(state, action.contacts)
     case TOGGLE_ACTIVE:
       let existingFriend = findFriend(state, action.friend)
       let isActive = (existingFriend ? existingFriend.isActive : false)

--- a/HelloAgain/reducers/index.js
+++ b/HelloAgain/reducers/index.js
@@ -2,9 +2,11 @@
 
 import { combineReducers } from 'redux'
 import friends from './friends'
+import contactImport from './contact-import'
 
 const mainReducer = combineReducers({
-  friends
+  friends,
+  contactImport
 })
 
 export default mainReducer

--- a/HelloAgain/store.js
+++ b/HelloAgain/store.js
@@ -1,11 +1,12 @@
 'use strict';
 
-import { createStore } from 'redux'
+import { createStore, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
 import mainReducer from './reducers'
 
 // Purely for testing new components. Will be removed later.
-import initialState from './store-scaffold'
+// import initialState from './store-scaffold'
 
-const store = createStore(mainReducer, initialState)
+const store = createStore(mainReducer, applyMiddleware(thunk))
 
 export default store


### PR DESCRIPTION
Using [react-native-contacts](https://github.com/rt2zz/react-native-contacts), load the native contact database into the friend store when the root component mounts.

`HelloAgain.componentWillMount()` actually dispatches a "[thunk](https://github.com/gaearon/redux-thunk)" action to the redux store called `loadNativeContacts`. This action creates a `Promise` around `Contacts.getAll()`, and triggers either a success or failure action on fulfillment or rejection of the promise.

A new `contactImport` reducer maintains state around the results of the contact import, and any errors that occur. Future work will need to deal with how to respond when a user (accidentally?) refuses permission to access the device contacts.

Also, the original `friends` reducer listens for the import success action, and responds by importing the contact database en masse. Right now the `friends` reducer uses the imported contacts as a set of "default values" to fill out whatever might already be in the store, without overwriting anything.

Fortunately `react-native-contacts` allows writing to native contact records as well, which is a relief, because there seems to be no cross-platform way to get a unique, permanent handle for a given contact record. In future work, we will want to generate a HelloAgain-specific unique identifier for each contact (when toggled active) and set that on the native contact record, so that we can enable users to follow their contacts across different devices, etc.

Doing this app-specific per-contact UUID would also give us the ability to do things like update contact names and other details when they change in the underlying native contact record.

But... it works! 📱 

@obra over to you