### PR TITLE
Generate a unique ID for each contact.

### DIFF
--- a/HelloAgain/__tests__/fixtures/friends.js
+++ b/HelloAgain/__tests__/fixtures/friends.js
@@ -1,10 +1,14 @@
 "use strict";
 
 import {CONTACT_FIXTURE} from "./contacts"
+import {generateHelloAgainID} from "../../reducers/friends"
 
 export const copyFriendsFixture = () => {
   const fixture = {}
-  CONTACT_FIXTURE.forEach((item) => {fixture[item.recordID] = {...item}})
+  CONTACT_FIXTURE.forEach((item) => {
+    let id = generateHelloAgainID(item)
+    fixture[id] = {helloAgainID: id, ...item}
+  })
   return fixture
 }
 

--- a/HelloAgain/__tests__/reducers/friends.js
+++ b/HelloAgain/__tests__/reducers/friends.js
@@ -7,8 +7,8 @@ import * as importActions from '../../actions/contact-import'
 import { copyFriendsFixture } from "../fixtures/friends"
 
 describe('friends reducer', () => {
-  let bob = {name: "Bob", recordID: 50}
-  let jim = {name: "Jim", recordID: 42}
+  let bob = {name: "Bob", helloAgainID: "bob-5555"}
+  let jim = {name: "Jim", helloAgainID: "jim-4242"}
 
   it('should return an initial state', () => {
     expect(
@@ -18,10 +18,21 @@ describe('friends reducer', () => {
 
   describe('contactsLoaded action', () => {
     let initialState = copyFriendsFixture()
+    let randomPerson = Object.values(initialState)[0]
     it('should import contacts and overwrite existing values', () => {
       let contactImport = [
-        {recordID: 1, phoneNumber: "800-555-1212"},
-        {recordID: 99, givenName: "Carl", familyName: "Sagan"}
+        {
+          urlAddresses: [{
+            label: "HelloAgain",
+            urlAddress: randomPerson.helloAgainID
+          }],
+          phoneNumber: "800-555-1212"
+        },
+        {
+          recordID: 99,
+          givenName: "Carl",
+          familyName: "Sagan"
+        }
       ]
       expect(
         friends(initialState, importActions.contactsLoaded(contactImport))
@@ -32,7 +43,7 @@ describe('friends reducer', () => {
   describe('updateFriend action', () => {
     let initialState = friends(undefined, actions.updateFriend(bob))
     it('should add a friend', () => {
-      expect(initialState).toEqual({50: bob})
+      expect(initialState).toEqual({[bob.helloAgainID]: bob})
     })
 
     it('should not duplicate an existing friend', () => {
@@ -42,15 +53,15 @@ describe('friends reducer', () => {
     })
 
     it("should merge a friend's existing record", () => {
-      let newFact = {recordID: 50, hobby: "fishing"}
+      let newFact = {helloAgainID: bob.helloAgainID, hobby: "fishing"}
       let newState = friends(initialState, actions.updateFriend(newFact))
-      expect(newState).toMatchObject({50: {...bob, ...newFact}})
+      expect(newState).toMatchObject({[bob.helloAgainID]: {...bob, ...newFact}})
     })
 
     it('should add a new friend', () => {
       expect(
         friends(initialState, actions.updateFriend(jim))
-      ).toEqual({50: bob, 42: jim})
+      ).toEqual({[bob.helloAgainID]: bob, [jim.helloAgainID]: jim})
     })
   })
 
@@ -61,8 +72,8 @@ describe('friends reducer', () => {
     )
     it('should update rank and contactedAt', () => {
       let newState = friends(initialState, actions.markAsContacted(bob))
-      expect(newState[bob.recordID].contactedAt).toBeTruthy()
-      expect(newState[bob.recordID].rank).toEqual(13)
+      expect(newState[bob.helloAgainID].contactedAt).toBeTruthy()
+      expect(newState[bob.helloAgainID].rank).toEqual(13)
     })
   })
 

--- a/HelloAgain/__tests__/store/filter.js
+++ b/HelloAgain/__tests__/store/filter.js
@@ -5,7 +5,7 @@ import { onlyActivatedFriends } from "../../store/filter"
 
 it('returns a function that filters all but activated friends', () => {
   const fixture = copyFriendsFixture()
-  fixture["1"].isActive = true
+  Object.values(fixture)[0].isActive = true
   const filtered = onlyActivatedFriends.in(fixture, "friends")
   expect(Object.keys(filtered).length).toEqual(1)
 })

--- a/HelloAgain/store/filter.js
+++ b/HelloAgain/store/filter.js
@@ -13,6 +13,6 @@ export const onlyActivatedFriends = createTransform((state, key) => {
   let filtered = {}
   Object.values(state)
     .filter(f => f.isActive !== undefined)
-    .forEach((f) => {filtered[f.recordID] = f})
+    .forEach((f) => {filtered[f.helloAgainID] = f})
   return filtered
 })


### PR DESCRIPTION
Rather than use `contact.recordID`, generate a `helloAgainID` for each contact during contact import, consisting of the contact's given and family names lowercased, and joined together with a hash of the recordID using dashes.

This unique ID format can later be used as a reasonable looking deep link URL to the contact from within the native contacts app, and it creates a persistent way of identifying a user.

I'm doing this hashing rather than generating a random string so that unit tests get consistent results. I'm using the `string-hash` library and it seems fast enough.

I'm only using 16 bits of the hash, because I want the ID to be as short as possible, and a birthday attack analysis suggests that you'd need to have 37 contacts with the *exact same name* to get a 1% chance of collision. Seems pretty unlikely.

**N.B.** In the future, I'm going to submit PRs _minus_ the snapshots, so that the code is even vaguely reviewable -- and then push up the snapshots after getting a :+1: but before merging.

This is the first half of resolving #66 -- the actual storing part will be in the next PR.

@obra please have a look.