### PR TITLE
Store unique IDs back to the native Contacts store.

### DIFF
--- a/HelloAgain/__mocks__/react-native-contacts.js
+++ b/HelloAgain/__mocks__/react-native-contacts.js
@@ -1,0 +1,8 @@
+'use strict'
+
+import {CONTACT_FIXTURE} from '../__tests__/fixtures/contacts'
+
+export default {
+  getAll: (fn) => fn(null, CONTACT_FIXTURE),
+  updateContact: (contact, fn) => fn(null, contact)
+}

--- a/HelloAgain/__tests__/actions/__snapshots__/contact-import.js.snap
+++ b/HelloAgain/__tests__/actions/__snapshots__/contact-import.js.snap
@@ -9,11 +9,11 @@ exports[`contactsLoaded should return an action 1`] = `
 Object {
   "contacts": Array [
     Object {
-      "name": "Bob",
+      "familyName": "Dobbs",
+      "givenName": "Bob",
+      "helloAgainID": "bob-dobbs-5555",
     },
   ],
   "type": "CONTACTS_LOADED",
 }
 `;
-
-exports[`loadNativeContacts should return a thunk 1`] = `[Function]`;

--- a/HelloAgain/__tests__/actions/__snapshots__/contact.js.snap
+++ b/HelloAgain/__tests__/actions/__snapshots__/contact.js.snap
@@ -1,8 +1,11 @@
-exports[`toggleActive should return an action 1`] = `
-Object {
-  "friend": Object {
-    "name": "Bob",
+exports[`toggleActive should dispatch a TOGGLE_ACTIVE action 1`] = `
+Array [
+  Object {
+    "friend": Object {
+      "givenName": "Bob",
+      "helloAgainID": "bob-5555",
+    },
+    "type": "TOGGLE_ACTIVE",
   },
-  "type": "TOGGLE_ACTIVE",
-}
+]
 `;

--- a/HelloAgain/__tests__/actions/contact-import.js
+++ b/HelloAgain/__tests__/actions/contact-import.js
@@ -1,8 +1,15 @@
 'use strict';
 
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import {CONTACT_FIXTURE} from '../fixtures/contacts'
+import {CONTACTS_LOADED} from '../../actions/types'
 import * as actions from '../../actions/contact-import'
+import Contacts from 'react-native-contacts'
+jest.mock('react-native-contacts')
 
-let bob = {name: "Bob"};
+const bob = {helloAgainID: "bob-dobbs-5555", givenName: "Bob", familyName: "Dobbs"}
+const mockStore = configureMockStore([thunk])
 
 describe('contactsLoaded', () => {
   it('should return an action', () => {
@@ -21,9 +28,44 @@ describe('contactLoadFailed', () => {
 })
 
 describe('loadNativeContacts', () => {
-  it('should return a thunk', () => {
-    expect(
-      actions.loadNativeContacts()
-    ).toMatchSnapshot()
+  const store = mockStore({})
+  it('should dispatch CONTACTS_LOADED', () => {
+    store.dispatch(actions.loadNativeContacts())
+      .then(() => {
+        let dispatched = store.getActions()
+        expect(dispatched[0].type).toBe(CONTACTS_LOADED)
+        expect(dispatched[0].contacts.length).toBeGreaterThan(0)
+      })
+      .catch(err => console.error(err))
+  })
+})
+
+describe('writeIDtoNativeContact', () => {
+  it('should not write a never-active contact', () => {
+    Contacts.updateContact = jest.fn()
+    actions.writeIDtoNativeContact(bob)
+    expect(Contacts.updateContact).not.toHaveBeenCalled()
+  })
+  it('should not write a contact that already has a URL', () => {
+    Contacts.updateContact = jest.fn()
+    actions.writeIDtoNativeContact({
+      ...bob, 
+      urlAddresses: [
+        {label: "HelloAgain", urlAddress: "helloagain://to/bob-dobbs-5555"}
+      ],
+      isActive: true
+    })
+    expect(Contacts.updateContact).not.toHaveBeenCalled()
+  })
+  it('should write a contact that doesn\'t have a deep link', () => {
+    for (let isActive of [true, false]) {
+      let updatedContact = null
+      Contacts.updateContact = jest.fn(contact => {updatedContact = contact})
+      actions.writeIDtoNativeContact({...bob, urlAddresses: [], isActive: isActive})
+      expect(Contacts.updateContact).toHaveBeenCalled()
+      let url = updatedContact.urlAddresses[0]
+      expect(url.label).toBe("HelloAgain")
+      expect(url.urlAddress).toBe("helloagain://to/" + bob.helloAgainID)
+    }
   })
 })

--- a/HelloAgain/__tests__/actions/contact.js
+++ b/HelloAgain/__tests__/actions/contact.js
@@ -1,12 +1,23 @@
 'use strict';
 
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 import * as actions from '../../actions/contact'
+import * as importActions from '../../actions/contact-import'
 
+const mockStore = configureMockStore([thunk])
 describe('toggleActive', () => {
-  it('should return an action', () => {
-    let bob = {name: "Bob"};
-    expect(
-      actions.toggleActive(bob)
-    ).toMatchSnapshot()
+  const bob = {helloAgainID: "bob-5555", givenName: "Bob"}
+  const store = mockStore({friends: {[bob.helloAgainID]: bob}})
+
+  it('should dispatch a TOGGLE_ACTIVE action', () => {
+    // Mock the native contacts write function
+    importActions.writeIDtoNativeContact = jest.fn()
+    // Dispatch the thunk action and make sure
+    store.dispatch(actions.toggleActive(bob))
+    // 1. the TOGGLE_ACTIVE action got dispatched
+    expect(store.getActions()).toMatchSnapshot()
+    // 2. writeIDtoNativeContact gets called
+    expect(importActions.writeIDtoNativeContact).toHaveBeenCalledWith(bob)
   })
 })

--- a/HelloAgain/__tests__/containers/contact-picker.js
+++ b/HelloAgain/__tests__/containers/contact-picker.js
@@ -4,12 +4,13 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme'
 import configureStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 
 import { TOGGLE_ACTIVE } from "../../actions/types"
 import ContactPicker from "../../containers/contact-picker"
 import { FRIENDS_FIXTURE } from "../fixtures/friends"
 
-const mockStore = configureStore([])
+const mockStore = configureStore([thunk])
 const store = mockStore({friends: FRIENDS_FIXTURE})
 
 it('renders something', () => {

--- a/HelloAgain/actions/contact-import.js
+++ b/HelloAgain/actions/contact-import.js
@@ -15,15 +15,70 @@ export const contactLoadFailed = (error) => {
 }
 
 export const loadNativeContacts = () => {
+  // Create a Promise that gets all native contacts and resolves on success.
   const loadContacts = new Promise((resolve, reject) => {
     Contacts.getAll((err, contacts) => {
       err ? reject(err) : resolve(contacts)
     })
   })
+  // Return an action thunk that:
+  //   1. Loads all contacts
+  //   2. On success, dispatches the `contactsLoaded` action
+  //   3. Then, dispatches the `writeIDsForAllFriends` to write back any new
+  //      IDs to the native contact store
+  //   4. On failure, dispatch the `contactLoadFailed` action
   return dispatch => {
-    loadContacts.then(
-      contacts => { dispatch(contactsLoaded(contacts)) },
-      error => { dispatch(contactLoadFailed(error)) }
-    )
+    return loadContacts
+      .then(contacts => {
+        let result = dispatch(contactsLoaded(contacts))
+        console.log("contactsLoaded:", Object.values(result).length)
+      })
+      .then(_ => { return dispatch(writeIDsForAllFriends()) })
+      .catch(error => dispatch(contactLoadFailed(error)))
+  }
+}
+
+const generateURL = (item) => {
+  return "helloagain://to/" + item.helloAgainID
+}
+
+// Check a single contact record to see if it needs the HelloAgain URL
+// written to it, and if it does, write it.
+export const writeIDtoNativeContact = (item) => {
+  // Never been active? Don't touch the native contact.
+  if (item.isActive === undefined) {
+    return
+  }
+  // Are any of the contact's urlAddresses a HelloAgain address? Great. Skip
+  // this one.
+  let matchingURLs = (item.urlAddresses || []).filter(url => url.label == "HelloAgain")
+  if (matchingURLs.length > 0) {
+    return
+  }
+  // Otherwise, generate the URL, push it onto the urlAddresses list with the
+  // right label, and then update the native contact store, with a log message
+  // either way.
+  let url = generateURL(item)
+  item.urlAddresses.push({label: "HelloAgain", urlAddress: url})
+  Contacts.updateContact(item, (err, contact) => {
+    if (err) {
+      console.log(`Error updating ${item.givenName} ${item.familyName} ` +
+                  `with URL ${url}:`, err, contact)
+    } else {
+      console.log(`Wrote URL to Contacts: ${url}`)
+    }
+  })
+}
+
+const writeIDsForAllFriends = () => {
+  // Return an action thunk that is pure side-effects -- just iterate
+  // over the entire set of contacts and make sure that any once-active friends
+  // that don't have HelloAgain URLs associated with them get one. This
+  // shouldn't really ever happen, because the `toggleActive` action takes care
+  // of the records one-by-one, but I guess it can't hurt to be certain.
+  return (_, getState) => {
+    const state = getState()
+    const friends = Object.values(state.friends).filter(f => f.isActive !== undefined)
+    friends.forEach(item => writeIDtoNativeContact(item))
   }
 }

--- a/HelloAgain/actions/contact.js
+++ b/HelloAgain/actions/contact.js
@@ -1,9 +1,15 @@
 'use strict'
 
-import {
-  TOGGLE_ACTIVE
-} from './types';
+import { TOGGLE_ACTIVE } from './types';
+import { writeIDtoNativeContact } from './contact-import'
 
 export const toggleActive = (friend) => {
-  return { type: TOGGLE_ACTIVE, friend: friend }
+  // The `toggleActive` action returns a thunk that:
+  //   a) dispatches a TOGGLE_ACTIVE action to update the friend store
+  //   b) ensures that the HelloAgain ID is persisted in the contacts store in
+  //      the form of a deep link
+  return dispatch => {
+    dispatch({ type: TOGGLE_ACTIVE, friend: friend })
+    writeIDtoNativeContact(friend)
+  }
 }

--- a/HelloAgain/actions/contact.js
+++ b/HelloAgain/actions/contact.js
@@ -4,12 +4,6 @@ import { TOGGLE_ACTIVE } from './types';
 import { writeIDtoNativeContact } from './contact-import'
 
 export const toggleActive = (friend) => {
-  // The `toggleActive` action returns a thunk that:
-  //   a) dispatches a TOGGLE_ACTIVE action to update the friend store
-  //   b) ensures that the HelloAgain ID is persisted in the contacts store in
-  //      the form of a deep link
-  return dispatch => {
-    dispatch({ type: TOGGLE_ACTIVE, friend: friend })
-    writeIDtoNativeContact(friend)
-  }
+  writeIDtoNativeContact(friend)
+  return { type: TOGGLE_ACTIVE, friend: friend }
 }


### PR DESCRIPTION
In point of fact, store the unique ID as a URL address field of type "HelloAgain" in the corresponding native Contact record. This custom URL will actually be visible to the user, and be _clickable_ once we get deep links into the app wired up in iOS.

The deep link takes the form: `helloagain://to/first-last-abcd`

The code currently writes back the unique deep link whenever a friend is toggled. Also, when contacts are imported, they're searched for missing deep links and the links are written back at that time, although this shouldn't really happen.

What's great about this is that now any aspect of a native contact record can change (aside from the HelloAgain deep link) and the contact's identity will still match up with their HelloAgain friend record -- even across devices (or even possibly platforms, when we get that far).

@obra!