### PR TITLE
Replace redux-thunk with redux-side-effect.

### DIFF
--- a/HelloAgain/__tests__/actions/contact-import.js
+++ b/HelloAgain/__tests__/actions/contact-import.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import {CONTACT_FIXTURE} from '../fixtures/contacts'
 import {CONTACTS_LOADED} from '../../actions/types'
 import * as actions from '../../actions/contact-import'
@@ -9,7 +8,7 @@ import Contacts from 'react-native-contacts'
 jest.mock('react-native-contacts')
 
 const bob = {helloAgainID: "bob-dobbs-5555", givenName: "Bob", familyName: "Dobbs"}
-const mockStore = configureMockStore([thunk])
+const mockStore = configureMockStore()
 
 describe('contactsLoaded', () => {
   it('should return an action', () => {
@@ -30,8 +29,8 @@ describe('contactLoadFailed', () => {
 describe('loadNativeContacts', () => {
   const store = mockStore({})
   it('should dispatch CONTACTS_LOADED', () => {
-    store.dispatch(actions.loadNativeContacts())
-      .then(() => {
+    Contacts.getAll = jest.fn(_ => Promise.resolve(CONTACT_FIXTURE))
+    actions.loadNativeContacts(store).then(() => {
         let dispatched = store.getActions()
         expect(dispatched[0].type).toBe(CONTACTS_LOADED)
         expect(dispatched[0].contacts.length).toBeGreaterThan(0)

--- a/HelloAgain/__tests__/actions/contact.js
+++ b/HelloAgain/__tests__/actions/contact.js
@@ -1,23 +1,11 @@
 'use strict';
 
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 import * as actions from '../../actions/contact'
-import * as importActions from '../../actions/contact-import'
 
-const mockStore = configureMockStore([thunk])
+const bob = {helloAgainID: "bob-dobbs-5555", givenName: "Bob", familyName: "Dobbs"}
+
 describe('toggleActive', () => {
-  const bob = {helloAgainID: "bob-5555", givenName: "Bob"}
-  const store = mockStore({friends: {[bob.helloAgainID]: bob}})
-
   it('should dispatch a TOGGLE_ACTIVE action', () => {
-    // Mock the native contacts write function
-    importActions.writeIDtoNativeContact = jest.fn()
-    // Dispatch the thunk action and make sure
-    store.dispatch(actions.toggleActive(bob))
-    // 1. the TOGGLE_ACTIVE action got dispatched
-    expect(store.getActions()).toMatchSnapshot()
-    // 2. writeIDtoNativeContact gets called
-    expect(importActions.writeIDtoNativeContact).toHaveBeenCalledWith(bob)
+    expect(actions.toggleActive(bob)).toMatchSnapshot()
   })
 })

--- a/HelloAgain/__tests__/containers/contact-picker.js
+++ b/HelloAgain/__tests__/containers/contact-picker.js
@@ -4,13 +4,12 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme'
 import configureStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
 
 import { TOGGLE_ACTIVE } from "../../actions/types"
 import ContactPicker from "../../containers/contact-picker"
 import { FRIENDS_FIXTURE } from "../fixtures/friends"
 
-const mockStore = configureStore([thunk])
+const mockStore = configureStore()
 const store = mockStore({friends: FRIENDS_FIXTURE})
 
 it('renders something', () => {

--- a/HelloAgain/actions/contact.js
+++ b/HelloAgain/actions/contact.js
@@ -1,9 +1,7 @@
 'use strict'
 
 import { TOGGLE_ACTIVE } from './types';
-import { writeIDtoNativeContact } from './contact-import'
 
 export const toggleActive = (friend) => {
-  writeIDtoNativeContact(friend)
   return { type: TOGGLE_ACTIVE, friend: friend }
 }

--- a/HelloAgain/containers/app.js
+++ b/HelloAgain/containers/app.js
@@ -14,7 +14,7 @@ export default class HelloAgain extends Component {
   }
 
   componentWillMount() {
-    store.dispatch(loadNativeContacts())
+    loadNativeContacts(store)
   }
 
   pickContacts() {

--- a/HelloAgain/package.json
+++ b/HelloAgain/package.json
@@ -15,7 +15,7 @@
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-persist": "^4.0.1",
-    "redux-thunk": "^2.1.0"
+    "redux-side-effects": "^1.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/HelloAgain/reducers/friends.js
+++ b/HelloAgain/reducers/friends.js
@@ -6,6 +6,7 @@ import {
   CONTACTS_LOADED,
   MARK_AS_CONTACTED
 } from '../actions/types'
+import { writeIDtoNativeContact } from '../actions/contact-import'
 import stringHash from 'string-hash'
 
 const findFriend = (state, friend) => {
@@ -79,6 +80,8 @@ const friends = (state = {}, action) => {
       let existingFriend = findFriend(state, action.friend)
       let isActive = (existingFriend ? existingFriend.isActive : false)
       let update = {...action.friend, isActive: !isActive}
+      // Update the native contact store
+      action.sideEffect(_ => writeIDtoNativeContact(update))
       // Set default values (if needed) when toggling a friend
       return updateFriend(state, update, true)
     case MARK_AS_CONTACTED:

--- a/HelloAgain/store/index.js
+++ b/HelloAgain/store/index.js
@@ -2,13 +2,13 @@
 
 import { createStore, applyMiddleware, compose } from 'redux'
 import { persistStore, autoRehydrate } from 'redux-persist'
-import thunk from 'redux-thunk'
+import { actionSideEffectMiddleware } from 'redux-side-effect'
 import { AsyncStorage } from 'react-native'
 import { onlyActivatedFriends } from './filter'
 import mainReducer from '../reducers'
 
 const enhancers = compose(
-  applyMiddleware(thunk),
+  applyMiddleware(actionSideEffectMiddleware),
   autoRehydrate()
 )
 const store = createStore(mainReducer, enhancers)


### PR DESCRIPTION
**TL;DR:** This replaces the somewhat complex system of thunk actions originally developed for importing from and exporting to the native contact store.

Instead, `loadNativeContacts()` is now just a regular static function that takes a `store` argument and dispatches the import actions to it, and the export of HelloAgain IDs on `toggleActive` is just called as a side effect from the `friends` reducer.

**More detail:**

Redux is great because it helps you separate functional concerns from side effects in user applications!

However, the Redux community seems to have no consensus on what to do with the side effects themselves. All of the add-on solutions are either wrapped in multiple layers of indirect execution and thus hard to test (thunks) or wrapped in multiple layers of declarative syntax and thus hard to code.

Eschewing additional libraries and just putting the side effects in a Redux store subscriber combines action at a distance with the problem of not being able to know what action was just triggered.

The `redux-side-effect` middleware just attaches a `.sideEffect()` method to every action. It takes a callback that's executed after the reducers finish, so that the side effects can be bundled with the "business logic" in the reducer, but in a way that's isolated and can be turned on/off as needed for testing various parts of the system properly.

Also, fortunately in practice, the friends reducer stays pure-_ish_, because the `toggleActive` helloAgainID export side effect is idempotent.